### PR TITLE
Remove package clean up action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,9 +30,3 @@ jobs:
           DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}
         with:
           arguments: jib
-      - name: Delete old pre-released packages except for feature branch snapshots
-        uses: actions/delete-package-versions@v3
-        with:
-          package-name: 'caraml-store-registry'
-          min-versions-to-keep: 2
-          ignore-versions: '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$,.+-snapshot$'


### PR DESCRIPTION
Github delete package action currently doesn't work with ghcr container registry.