### PR TITLE
move jobservice proto to feast.core

### DIFF
--- a/caraml-store-protobuf/src/main/proto/feast/core/JobService.proto
+++ b/caraml-store-protobuf/src/main/proto/feast/core/JobService.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package feast_spark.api;
+package feast.core;
 
 option java_outer_classname = "JobServiceProto";
 option java_package = "dev.caraml.store.protobuf.jobservice";


### PR DESCRIPTION
Signed-off-by: KeshavSharma <keshav.sharma@gojek.com>

Move jobservice proto back to feast.core package to ensure backward compatibility with grpc clients.