### PR TITLE
Fix spark field mapping

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
@@ -31,7 +31,7 @@ object IngestionJob {
         val json = parseJSON(x)
         JsonUtils
           .mapFieldWithParent(json) {
-            case (parent: String, (key: String, v: JValue)) if !parent.equals("field_mapping") =>
+            case (parent: String, (key: String, v: JValue)) if !parent.equals("fieldMapping") =>
               JsonUtils.camelize(key) -> v
             case (_, x) => x
           }


### PR DESCRIPTION
The source mapping is not working as intended at the moment since the argument is now in camelCase rather than snake case.