### PR TITLE
Add compatibility layer to support older client

### DIFF
--- a/caraml-store-protobuf/src/main/proto/feast/core/LegacyJobService.proto
+++ b/caraml-store-protobuf/src/main/proto/feast/core/LegacyJobService.proto
@@ -1,0 +1,24 @@
+// Legacy compatibility endpoint for older version of feast client.
+// The new endpoint is defined in feast_spark/api/JobService.proto
+
+syntax = "proto3";
+package feast.core;
+
+option java_outer_classname = "JobServiceProto";
+option java_package = "dev.caraml.store.protobuf.compat";
+
+import "google/protobuf/timestamp.proto";
+import "feast/core/DataSource.proto";
+import "feast_spark/api/JobService.proto";
+
+
+service JobService {
+  // Start job to ingest data from offline store into online store
+  rpc StartOfflineToOnlineIngestionJob (feast_spark.api.StartOfflineToOnlineIngestionJobRequest) returns (feast_spark.api.StartOfflineToOnlineIngestionJobResponse);
+
+  // Produce a training dataset, return a job id that will provide a file reference
+  rpc GetHistoricalFeatures (feast_spark.api.GetHistoricalFeaturesRequest) returns (feast_spark.api.GetHistoricalFeaturesResponse);
+
+  // Get details of a single job
+  rpc GetJob (feast_spark.api.GetJobRequest) returns (feast_spark.api.GetJobResponse);
+}

--- a/caraml-store-registry/src/main/java/dev/caraml/store/api/compat/LegacyJobGrpcServiceImpl.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/api/compat/LegacyJobGrpcServiceImpl.java
@@ -1,0 +1,81 @@
+package dev.caraml.store.api.compat;
+
+import dev.caraml.store.protobuf.compat.JobServiceGrpc;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.GetHistoricalFeaturesRequest;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.GetHistoricalFeaturesResponse;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.GetJobRequest;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.GetJobResponse;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.Job;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.StartOfflineToOnlineIngestionJobRequest;
+import dev.caraml.store.protobuf.jobservice.JobServiceProto.StartOfflineToOnlineIngestionJobResponse;
+import dev.caraml.store.sparkjob.JobNotFoundException;
+import dev.caraml.store.sparkjob.JobService;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.server.service.GrpcService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+// Endpoint to support backward compatibility for users who still use feast
+// as opposed to feast_spark client
+@Slf4j
+@GrpcService
+public class LegacyJobGrpcServiceImpl extends JobServiceGrpc.JobServiceImplBase {
+  private final JobService jobService;
+
+  @Autowired
+  public LegacyJobGrpcServiceImpl(JobService jobService) {
+    this.jobService = jobService;
+  }
+
+  @Override
+  public void startOfflineToOnlineIngestionJob(
+      StartOfflineToOnlineIngestionJobRequest request,
+      StreamObserver<StartOfflineToOnlineIngestionJobResponse> responseObserver) {
+    Job job =
+        jobService.createOrUpdateBatchIngestionJob(
+            request.getProject(),
+            request.getTableName(),
+            request.getStartDate(),
+            request.getEndDate());
+    StartOfflineToOnlineIngestionJobResponse response =
+        StartOfflineToOnlineIngestionJobResponse.newBuilder()
+            .setJobStartTime(job.getStartTime())
+            .setId(job.getId())
+            .setTableName(request.getTableName())
+            .build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getHistoricalFeatures(
+      GetHistoricalFeaturesRequest request,
+      StreamObserver<GetHistoricalFeaturesResponse> responseObserver) {
+    Job job =
+        jobService.createRetrievalJob(
+            request.getProject(),
+            request.getFeatureRefsList(),
+            request.getEntitySource(),
+            request.getOutputFormat(),
+            request.getOutputLocation());
+    GetHistoricalFeaturesResponse response =
+        GetHistoricalFeaturesResponse.newBuilder()
+            .setId(job.getId())
+            .setJobStartTime(job.getStartTime())
+            .setOutputFileUri(request.getOutputLocation())
+            .build();
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getJob(GetJobRequest request, StreamObserver<GetJobResponse> responseObserver) {
+    GetJobResponse response =
+        jobService
+            .getJob(request.getJobId())
+            .map(job -> GetJobResponse.newBuilder().setJob(job).build())
+            .orElseThrow(() -> new JobNotFoundException(request.getJobId()));
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+}


### PR DESCRIPTION
Users who are still using feast client as opposed to feast_spark client are not able to use the current Caraml Store Registry due to difference in grpc method name.