### PR TITLE
Use default store if store name is unset in the feature spec

### DIFF
--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/DefaultStore.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/DefaultStore.java
@@ -1,0 +1,3 @@
+package dev.caraml.store.sparkjob;
+
+public record DefaultStore(String stream, String batch) {}

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobServiceConfig.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobServiceConfig.java
@@ -17,4 +17,5 @@ public class JobServiceConfig {
   private List<IngestionJobProperties> streamIngestion = new ArrayList<>();
   private List<IngestionJobProperties> batchIngestion = new ArrayList<>();
   private HistoricalRetrievalJobProperties historicalRetrieval;
+  private DefaultStore defaultStore;
 }

--- a/caraml-store-registry/src/main/resources/application.yaml
+++ b/caraml-store-registry/src/main/resources/application.yaml
@@ -27,11 +27,11 @@ caraml:
   jobService:
     namespace: spark-operator
     streamIngestion:
-      - store: store-name
+      - store: default-store
         # Stream ingestion spark application spec
         # sparkApplicationSpec:
     batchIngestion:
-      - store: store-name
+      - store: default-store
         # Batch ingestion spark application spec
         # sparkApplicationSpec:
     historicalRetrieval:
@@ -45,6 +45,10 @@ caraml:
            cores: 1
            instances: 1
            memory: "6144m"
+    # Default store for ingestion if store name is not specified in the feature table
+    defaultStore:
+      stream: default-store
+      batch: default-store
 
 grpc:
   server:

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobServiceTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobServiceTest.java
@@ -72,6 +72,7 @@ public class JobServiceTest {
     JobServiceConfig properties = new JobServiceConfig();
     properties.setNamespace("spark-operator");
     properties.setBatchIngestion(jobs);
+    properties.setDefaultStore(new DefaultStore("store", "store"));
     IngestionJobProperties batchJobProperty =
         new IngestionJobProperties("store", new SparkApplicationSpec());
     jobs.add(batchJobProperty);
@@ -129,6 +130,7 @@ public class JobServiceTest {
     JobServiceConfig properties = new JobServiceConfig();
     properties.setNamespace("spark-operator");
     properties.setStreamIngestion(jobs);
+    properties.setDefaultStore(new DefaultStore("store", "store"));
     IngestionJobProperties streamJobProperty =
         new IngestionJobProperties("store", new SparkApplicationSpec());
     jobs.add(streamJobProperty);


### PR DESCRIPTION
This is to facilitate migration for users who are still using the older client version.