### PR TITLE
Fix store configuration

### DIFF
--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableStoreConfig.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableStoreConfig.java
@@ -13,7 +13,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix = "caraml.store.bigtable")
-@ConditionalOnProperty("caraml.store.bigtable.enabled")
+@ConditionalOnProperty(prefix = "caraml.store", name = "active", havingValue = "bigtable")
 @Getter
 @Setter
 public class BigTableStoreConfig {

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/redis/RedisClient.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/redis/RedisClient.java
@@ -44,7 +44,7 @@ public class RedisClient implements RedisClientAdapter {
     }
     RedisURI uri = uriBuilder.build();
 
-    TCPConfig tcpConfig = config.getTcpConfig();
+    TCPConfig tcpConfig = config.getTcp();
     io.lettuce.core.RedisClient client =
         tcpConfig == null
             ? io.lettuce.core.RedisClient.create(uri)

--- a/caraml-store-serving/src/main/resources/application.yaml
+++ b/caraml-store-serving/src/main/resources/application.yaml
@@ -10,33 +10,46 @@ caraml:
       refreshInterval: 60
 
   store:
+    # Active store. Possible values: [redisCluster, redis, bigtable]
+    active: redis
+
+    redis:
+      host: localhost
+      port: 6379
+      password: ""
+      ssl: false
+
     redisCluster:
-      enabled: true
       # Connection string specifies the host:port of Redis instances in the redis cluster.
       connectionString: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
-      # Uncomment to enable password authentication
-      # password: password
+      # Password authentication. Empty string if password is not set.
+      password: ""
       readFrom: MASTER
       # Redis operation timeout in ISO-8601 format
       timeout: PT0.5S
-      # Allow customization of netty behaviour. false by default.
-      useNettyCustomizer: false
-      # Epoll Channel Option: TCP_KEEPIDLE
-      tcpKeepIdle: 15
-      # Epoll Channel Option: TCP_KEEPINTVL
-      tcpKeepInterval: 5
-      # Epoll Channel Option: TCP_KEEPCNT
-      tcpKeepConnection: 3
-      # Epoll Channel Option: TCP_USER_TIMEOUT
-      tcpUserConnection: 60000
-      # redis cluster topology refresh config
-      topologyRefresh:
-        # enable adaptive topology refresh from all triggers : MOVED_REDIRECT, ASK_REDIRECT, PERSISTENT_RECONNECTS, UNKNOWN_NODE (since 5.1), and UNCOVERED_SLOT (since 5.2) (see also reconnect attempts for the reconnect trigger)
-        enableAllAdaptiveTriggerRefresh: true
-        # enable periodic refresh
-        enablePeriodicRefresh: false
-        # topology refresh period in seconds
-        refreshPeriodSecond: 30
+#      # Uncomment to customize netty behaviour
+#      tcp:
+#        # Epoll Channel Option: TCP_KEEPIDLE
+#        keepIdle: 15
+#        # Epoll Channel Option: TCP_KEEPINTVL
+#        keepInterval: 5
+#        # Epoll Channel Option: TCP_KEEPCNT
+#        keepConnection: 3
+#        # Epoll Channel Option: TCP_USER_TIMEOUT
+#        userConnection: 60000
+#      # Uncomment to customize redis cluster topology refresh config
+#      topologyRefresh:
+#        # enable adaptive topology refresh from all triggers : MOVED_REDIRECT, ASK_REDIRECT, PERSISTENT_RECONNECTS, UNKNOWN_NODE (since 5.1), and UNCOVERED_SLOT (since 5.2) (see also reconnect attempts for the reconnect trigger)
+#        enableAllAdaptiveTriggerRefresh: true
+#        # enable periodic refresh
+#        enablePeriodicRefresh: false
+#        # topology refresh period in seconds
+#        refreshPeriodSecond: 30
+
+    bigtable:
+      projectId: gcp-project-name
+      instanceId: bigtable-instance
+      appProfileId: default
 
 grpc:
   server:


### PR DESCRIPTION
Currently it's not possible to overwrite the store configuration to use stores other than default unless the application.yaml resource is not in the configuration path. Similar with tcp config and topology refresh configuration.