### PR TITLE
Update bigtable client

### DIFF
--- a/caraml-store-serving/build.gradle
+++ b/caraml-store-serving/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'com.google.guava:guava:26.0-jre'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'org.apache.avro:avro:1.10.2'
-    implementation 'com.google.cloud:google-cloud-bigtable:1.21.2'
+    implementation 'com.google.cloud:google-cloud-bigtable:2.5.0'
     implementation 'io.lettuce:lettuce-core:6.2.0.RELEASE'
     implementation 'io.netty:netty-transport-native-epoll:4.1.52.Final:linux-x86_64'
     testImplementation project(':caraml-store-testutil')


### PR DESCRIPTION
The current version of bigtable client uses an older version of grpc-auth, which is incompatible with other dependencies.