### PR TITLE
Delegate historical retrieval task to BigQuery if feasible

### DIFF
--- a/caraml-store-pyspark/requirements.txt
+++ b/caraml-store-pyspark/requirements.txt
@@ -4,3 +4,4 @@ pytest-timeout==1.4.2
 pytest-ordering==0.6.*
 pytest-mock==1.10.4
 pyspark==3.1.3
+Jinja2==3.1.2

--- a/caraml-store-pyspark/templates/extract_timestamps.jinja2
+++ b/caraml-store-pyspark/templates/extract_timestamps.jinja2
@@ -1,0 +1,2 @@
+SELECT min({{ entity_source.event_timestamp_column }}) as min_event_timestamp, max({{ entity_source.event_timestamp_column }}) as max_event_timestamp
+FROM {{ entity_source.bq_ref }}

--- a/caraml-store-pyspark/templates/retrieval.jinja2
+++ b/caraml-store-pyspark/templates/retrieval.jinja2
@@ -1,0 +1,93 @@
+WITH entity_dataframe AS (
+SELECT *,
+{{ entity_source.event_timestamp_column }} AS entity_timestamp
+{% for feature_view in feature_views %}
+    ,CONCAT(
+    {% for entity in feature_view.entities %}
+        CAST({{entity}} AS STRING),
+    {% endfor %}
+    CAST({{entity_source.event_timestamp_column}} AS STRING)
+    ) AS {{feature_view.name}}__entity_row_unique_id
+{% endfor %}
+FROM `{{ entity_source.bq_ref }}`
+),
+
+{% for feature_view in feature_views %}
+    {{ feature_view.name }}__entity_dataframe AS (
+    SELECT
+    {{ feature_view.entities | join(', ')}},
+    entity_timestamp,
+    {{feature_view.name}}__entity_row_unique_id
+    FROM entity_dataframe
+    GROUP BY
+    {{ feature_view.entities | join(', ')}},
+    entity_timestamp,
+    {{feature_view.name}}__entity_row_unique_id
+    ),
+
+    {{ feature_view.name }}__subquery AS (
+    SELECT
+    {{ feature_view.event_timestamp_column }} as event_timestamp,
+    {{ feature_view.entity_selections | join(', ')}},
+    {% for feature in feature_view.features %}
+        {{ feature_view.field_mapping.get(feature, feature) }} as {{ feature_view.name }}__{{ feature }}{% if loop.last %}{% else %}, {% endif %}
+    {% endfor %}
+    FROM {{ feature_view.bq_ref }}
+    WHERE {{ feature_view.event_timestamp_column }} <= '{{ feature_view.max_event_timestamp.isoformat() }}'
+    AND {{ feature_view.event_timestamp_column }} >= '{{ feature_view.min_event_timestamp.isoformat() }}'
+    ),
+
+    {{ feature_view.name }}__base AS (
+    SELECT
+    subquery.*,
+    entity_dataframe.entity_timestamp,
+    entity_dataframe.{{feature_view.name}}__entity_row_unique_id
+    FROM {{ feature_view.name }}__subquery AS subquery
+    INNER JOIN {{ feature_view.name }}__entity_dataframe AS entity_dataframe
+    ON TRUE
+    AND subquery.event_timestamp <= entity_dataframe.entity_timestamp
+    AND subquery.event_timestamp >= Timestamp_sub(entity_dataframe.entity_timestamp, interval {{ feature_view.max_age }} second)
+    {% for entity in feature_view.entities %}
+        AND subquery.{{ entity }} = entity_dataframe.{{ entity }}
+    {% endfor %}
+    ),
+
+    {{ feature_view.name }}__latest AS (
+    SELECT
+    event_timestamp,
+    {{feature_view.name}}__entity_row_unique_id
+    FROM
+    (
+    SELECT *,
+    ROW_NUMBER() OVER(
+    PARTITION BY {{feature_view.name}}__entity_row_unique_id
+    ORDER BY event_timestamp DESC
+    ) AS row_number
+    FROM {{ feature_view.name }}__base
+    )
+    WHERE row_number = 1
+    ),
+
+    {{ feature_view.name }}__cleaned AS (
+    SELECT base.*
+    FROM {{ feature_view.name }}__base as base
+    INNER JOIN {{ feature_view.name }}__latest
+    USING(
+    {{feature_view.name}}__entity_row_unique_id,
+    event_timestamp
+    )
+    ){% if loop.last %}{% else %}, {% endif %}
+{% endfor %}
+
+SELECT {{ final_output_feature_names | join(', ')}}
+FROM entity_dataframe
+{% for feature_view in feature_views %}
+    LEFT JOIN (
+    SELECT
+    {{feature_view.name}}__entity_row_unique_id
+    {% for feature in feature_view.features %}
+        ,{{ feature_view.name }}__{{ feature }}
+    {% endfor %}
+    FROM {{ feature_view.name }}__cleaned
+    ) USING ({{feature_view.name}}__entity_row_unique_id)
+{% endfor %}

--- a/caraml-store-pyspark/tests/test_historical_feature_retrieval.py
+++ b/caraml-store-pyspark/tests/test_historical_feature_retrieval.py
@@ -1,5 +1,5 @@
 import pathlib
-from datetime import datetime, timedelta
+from datetime import datetime
 from os import path
 
 import pytest
@@ -20,7 +20,7 @@ from scripts.historical_feature_retrieval_job import (
     as_of_join,
     filter_feature_table_by_time_range,
     join_entity_to_feature_tables,
-    retrieve_historical_features,
+    retrieve_historical_features, source_from_dict, feature_table_from_dict,
 )
 
 
@@ -459,15 +459,15 @@ def test_multiple_join(
 
 def test_historical_feature_retrieval(spark: SparkSession):
     test_data_dir = path.join(pathlib.Path(__file__).parent.absolute(), "data")
-    entity_source = {
+    entity_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'customer_driver_pairs.csv')}",
             "eventTimestampColumn": "event_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    booking_source = {
+    })
+    booking_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'bookings.csv')}",
@@ -475,8 +475,8 @@ def test_historical_feature_retrieval(spark: SparkSession):
             "createdTimestampColumn": "created_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    transaction_source = {
+    })
+    transaction_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'transactions.csv')}",
@@ -484,19 +484,19 @@ def test_historical_feature_retrieval(spark: SparkSession):
             "createdTimestampColumn": "created_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    booking_table = {
+    })
+    booking_table = feature_table_from_dict({
         "name": "bookings",
         "entities": [{"name": "driver_id", "type": "int32"}],
         "features": [{"name": "completed_bookings", "type": "int32"}],
         "maxAge": 365 * 86400,
-    }
-    transaction_table = {
+    })
+    transaction_table = feature_table_from_dict({
         "name": "transactions",
         "entities": [{"name": "customer_id", "type": "int32"}],
         "features": [{"name": "daily_transactions", "type": "double"}],
         "maxAge": 86400,
-    }
+    })
 
     joined_df = retrieve_historical_features(
         spark,
@@ -531,7 +531,7 @@ def test_historical_feature_retrieval(spark: SparkSession):
 
 def test_historical_feature_retrieval_with_mapping(spark: SparkSession):
     test_data_dir = path.join(pathlib.Path(__file__).parent.absolute(), "data")
-    entity_source = {
+    entity_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'column_mapping_test_entity.csv')}",
@@ -539,8 +539,8 @@ def test_historical_feature_retrieval_with_mapping(spark: SparkSession):
             "fieldMapping": {"customer_id": "id"},
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    booking_source = {
+    })
+    booking_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'column_mapping_test_feature.csv')}",
@@ -548,13 +548,13 @@ def test_historical_feature_retrieval_with_mapping(spark: SparkSession):
             "createdTimestampColumn": "created_datetime",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    booking_table = {
+    })
+    booking_table = feature_table_from_dict({
         "name": "bookings",
         "entities": [{"name": "customer_id", "type": "int32"}],
         "features": [{"name": "total_bookings", "type": "int32"}],
         "maxAge": 86400,
-    }
+    })
 
     joined_df = retrieve_historical_features(
         spark, entity_source, [booking_source], [booking_table],
@@ -584,32 +584,32 @@ def test_historical_feature_retrieval_with_mapping(spark: SparkSession):
 
 def test_historical_feature_retrieval_with_schema_errors(spark: SparkSession):
     test_data_dir = path.join(pathlib.Path(__file__).parent.absolute(), "data")
-    entity_source = {
+    entity_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'customer_driver_pairs.csv')}",
             "eventTimestampColumn": "event_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    entity_source_missing_timestamp = {
+    })
+    entity_source_missing_timestamp = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'customer_driver_pairs.csv')}",
             "eventTimestampColumn": "datetime",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    entity_source_missing_entity = {
+    })
+    entity_source_missing_entity = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'customers.csv')}",
             "eventTimestampColumn": "event_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
+    })
 
-    booking_source = {
+    booking_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'bookings.csv')}",
@@ -617,8 +617,8 @@ def test_historical_feature_retrieval_with_schema_errors(spark: SparkSession):
             "createdTimestampColumn": "created_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    booking_source_missing_timestamp = {
+    })
+    booking_source_missing_timestamp = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'bookings.csv')}",
@@ -626,19 +626,19 @@ def test_historical_feature_retrieval_with_schema_errors(spark: SparkSession):
             "createdTimestampColumn": "created_datetime",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    booking_table = {
+    })
+    booking_table = feature_table_from_dict({
         "name": "bookings",
         "entities": [{"name": "driver_id", "type": "int32"}],
         "features": [{"name": "completed_bookings", "type": "int32"}],
         "maxAge": 86400,
-    }
-    booking_table_missing_features = {
+    })
+    booking_table_missing_features = feature_table_from_dict({
         "name": "bookings",
         "entities": [{"name": "driver_id", "type": "int32"}],
         "features": [{"name": "nonexist_feature", "type": "int32"}],
         "maxAge": 86400,
-    }
+    })
 
     with pytest.raises(SchemaError):
         retrieve_historical_features(
@@ -663,15 +663,15 @@ def test_historical_feature_retrieval_with_schema_errors(spark: SparkSession):
 
 def test_implicit_type_conversion(spark: SparkSession,):
     test_data_dir = path.join(pathlib.Path(__file__).parent.absolute(), "data")
-    entity_source = {
+    entity_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'single_customer.csv')}",
             "eventTimestampColumn": "event_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    transaction_source = {
+    })
+    transaction_source = source_from_dict({
         "file": {
             "format": {"jsonClass": "CSVFormat"},
             "path": f"file://{path.join(test_data_dir,  'transactions.csv')}",
@@ -679,13 +679,13 @@ def test_implicit_type_conversion(spark: SparkSession,):
             "createdTimestampColumn": "created_timestamp",
             "options": {"inferSchema": "true", "header": "true"},
         }
-    }
-    transaction_table = {
+    })
+    transaction_table = feature_table_from_dict({
         "name": "transactions",
         "entities": [{"name": "customer_id", "type": "int32"}],
         "features": [{"name": "daily_transactions", "type": "float"}],
         "maxAge": 86400,
-    }
+    })
 
     joined_df = retrieve_historical_features(
         spark, entity_source, [transaction_source], [transaction_table],

--- a/caraml-store-spark/docker/Dockerfile
+++ b/caraml-store-spark/docker/Dockerfile
@@ -7,6 +7,7 @@ USER root
 ADD https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-${GCS_CONNECTOR_VERSION}.jar /opt/spark/jars
 ADD https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/${BQ_CONNECTOR_VERSION}/spark-bigquery-with-dependencies_2.12-${BQ_CONNECTOR_VERSION}.jar /opt/spark/jars
 
+RUN pip install Jinja2==3.1.2
 # For logging to /dev/termination-log
 RUN mkdir -p /dev
 


### PR DESCRIPTION
In scenarios where entity source and all feature table sources are from BigQuery, we can delegate the historical retrieval job to BQ instead for better cost efficiency.