### PR TITLE
Remove strict version requirement for dependencies

### DIFF
--- a/caraml-store-python/setup.py
+++ b/caraml-store-python/setup.py
@@ -8,8 +8,8 @@ AUTHOR = "caraml-dev"
 REQUIRES_PYTHON = ">=3.7.0"
 
 REQUIRED = [
-    "grpcio==1.50.0",
-    "protobuf==4.21.9"
+    "grpcio>=1.50.0",
+    "protobuf>=4.21.9"
 ]
 
 # Add Support for parsing tags that have a prefix containing '/' (ie 'sdk/go') to setuptools_scm.


### PR DESCRIPTION
The existing python requirement is overly strict and can be relaxed.