### PR TITLE
Add support for timeout for BigTable retrieval

### DIFF
--- a/caraml-store-serving/src/main/resources/application.yaml
+++ b/caraml-store-serving/src/main/resources/application.yaml
@@ -66,6 +66,8 @@ caraml:
       instanceId: bigtable-instance
       appProfileId: default
       enableClientSideMetrics: false
+      # Timeout configuration for BigTable client. Set 0 to use the default client configuration.
+      timeoutMs: 0
 
 grpc:
   server:


### PR DESCRIPTION
Allow user to set timeout for bigtable client. By default, the default behaviour of the BigTable client applies.