### PR TITLE
fix: enable scheduling for feature cache refresh

### DIFF
--- a/caraml-store-serving/src/main/java/dev/caraml/serving/CaraMLServing.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/CaraMLServing.java
@@ -2,8 +2,10 @@ package dev.caraml.serving;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CaraMLServing {
   public static void main(String[] args) {
     SpringApplication.run(CaraMLServing.class, args);

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/StoreService.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/StoreService.java
@@ -112,7 +112,6 @@ public class StoreService {
   }
 
   private RetrievedOnlineFeatures retrieveOnlineFeatures(GetOnlineFeaturesRequest request) {
-
     String projectName = request.getProject();
     List<FeatureReference> featureReferences = request.getFeaturesList();
 

--- a/caraml-store-serving/src/main/resources/application.yaml
+++ b/caraml-store-serving/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ caraml:
       # Feature spec cache expiry (in hours after last access)
       expiry: 4
       # Initial delay before scheduling the cache refresh
-      initialDelay: 5000
+      initialDelay: 100
       # Frequency of refreshing cache (in milliseconds)
       refreshInterval: 60000
 


### PR DESCRIPTION
Feature cache is currently not being refreshed and only loaded once during start up, which means feature update is not being picked up by the serving service.