### PR TITLE
fix: incorrect initial delay string expression

### DIFF
--- a/caraml-store-serving/src/main/java/dev/caraml/serving/featurespec/FeatureSpecService.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/featurespec/FeatureSpecService.java
@@ -85,7 +85,7 @@ public class FeatureSpecService {
   }
 
   @Scheduled(
-      initialDelayString = "{caraml.registry.cache.initialDelay}",
+      initialDelayString = "${caraml.registry.cache.initialDelay}",
       fixedRateString = "${caraml.registry.cache.refreshInterval}")
   public void scheduledPopulateCache() {
     try {


### PR DESCRIPTION
The initial delay string expression was incorrect resulting in crash during start up.