### PR TITLE
fix: fix bigtable max age calculation

### DIFF
--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetriever.java
@@ -104,7 +104,7 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
                                     value,
                                     localFeatureReferences,
                                     reusedDecoder,
-                                    rowCell.getTimestamp());
+                                    rowCell.getTimestamp() / 1000);
                           } catch (IOException e) {
                             throw new RuntimeException("Failed to decode features from BigTable");
                           }


### PR DESCRIPTION
BigTable rowCell getTimestamp returns the timestamp as microseconds since epoch, instead of milliseconds as it was assumed in the original implementation.