### PR TITLE
feat: Add support for local rate limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ __pycache__/
 .mypy_cache/
 .pytest_cache/
 .eggs/
+*.egg-info/
 
 # Environments
 .env

--- a/caraml-store-spark/build.gradle
+++ b/caraml-store-spark/build.gradle
@@ -51,6 +51,7 @@ dependencies {
         }
     }
     implementation "org.json4s:json4s-ext_$scalaVersion:3.7.0-M5"
+    implementation 'com.bucket4j:bucket4j-core:8.5.0'
     testImplementation "org.scalatest:scalatest_$scalaVersion:3.2.2"
     testImplementation "org.scalacheck:scalacheck_$scalaVersion:1.14.3"
     testImplementation "com.dimafeng:testcontainers-scala-scalatest_$scalaVersion:0.40.12"

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -27,6 +27,8 @@ object BasePipeline {
           .set("spark.redis.ssl", ssl.toString)
           .set("spark.redis.properties.maxJitter", properties.maxJitterSeconds.toString)
           .set("spark.redis.properties.pipelineSize", properties.pipelineSize.toString)
+          .set("spark.redis.properties.enableRateLimit", properties.enableRateLimit.toString)
+          .set("spark.redis.properties.ratePerSecondLimit", properties.ratePerSecondLimit.toString)
       case BigTableConfig(projectId, instanceId) =>
         conf
           .set("spark.bigtable.projectId", projectId)

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -22,7 +22,9 @@ case class RedisConfig(
 case class RedisWriteProperties(
     maxJitterSeconds: Int = 3600,
     pipelineSize: Int = 250,
-    ttlSeconds: Long = 0L
+    ttlSeconds: Long = 0L,
+    enableRateLimit: Boolean = false,
+    ratePerSecondLimit: Int = 50000
 )
 case class BigTableConfig(projectId: String, instanceId: String) extends StoreConfig
 

--- a/caraml-store-spark/src/test/scala/dev/caraml/spark/BatchPipelineSpec.scala
+++ b/caraml-store-spark/src/test/scala/dev/caraml/spark/BatchPipelineSpec.scala
@@ -45,6 +45,8 @@ class BatchPipelineSpec extends SparkSpec with ForAllTestContainer {
     .set("spark.metrics.conf.*.sink.statsd.port", statsDStub.port.toString)
     .set("spark.redis.properties.maxJitter", "0")
     .set("spark.redis.properties.pipelineSize", "250")
+    .set("spark.redis.properties.enableRateLimit", "false")
+    .set("spark.redis.properties.ratePerSecondLimit", "50000")
 
   trait Scope {
     val jedis = new Jedis("localhost", container.mappedPort(6379))

--- a/caraml-store-spark/src/test/scala/dev/caraml/spark/StreamingPipelineSpec.scala
+++ b/caraml-store-spark/src/test/scala/dev/caraml/spark/StreamingPipelineSpec.scala
@@ -43,6 +43,8 @@ class StreamingPipelineSpec extends SparkSpec with ForAllTestContainer {
     .set("spark.sql.streaming.checkpointLocation", generateTempPath("checkpoint"))
     .set("spark.redis.properties.maxJitter", "0")
     .set("spark.redis.properties.pipelineSize", "250")
+    .set("spark.redis.properties.enableRateLimit", "false")
+    .set("spark.redis.properties.ratePerSecondLimit", "50000")
 
   trait KafkaPublisher {
     val props = new Properties()


### PR DESCRIPTION
Allow write ops to Redis sink to be rate limited using Bucket4j library.