### PR TITLE
fix: use singleton rate limiter 

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/redis/RateLimiter.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/redis/RateLimiter.scala
@@ -1,0 +1,29 @@
+package dev.caraml.spark.stores.redis
+
+import dev.caraml.spark.RedisWriteProperties
+import io.github.bucket4j.{Bandwidth, Bucket}
+
+import java.time.Duration.ofSeconds
+import java.util.concurrent.ConcurrentHashMap
+
+object RateLimiter {
+
+  private lazy val buckets: ConcurrentHashMap[RedisWriteProperties, Bucket] = new ConcurrentHashMap
+
+  def get(properties: RedisWriteProperties): Bucket = {
+    buckets.computeIfAbsent(properties, create)
+  }
+
+  def create(properties: RedisWriteProperties): Bucket = {
+    Bucket
+      .builder()
+      .addLimit(
+        Bandwidth
+          .builder()
+          .capacity(properties.ratePerSecondLimit)
+          .refillIntervally(properties.ratePerSecondLimit, ofSeconds(1))
+          .build()
+      )
+      .build()
+  }
+}


### PR DESCRIPTION
Currently, the rate limiter bucket will be instantiated more than once in the presence of multiple partition. We will use singleton pattern instead to make sure that only one limiter is created per executor.