### PR TITLE
Relax Python SDK protobuf dependency

### DIFF
--- a/caraml-store-sdk/python/setup.py
+++ b/caraml-store-sdk/python/setup.py
@@ -9,7 +9,7 @@ REQUIRES_PYTHON = ">=3.8.0"
 
 REQUIRED = [
     "grpcio>=1.50.0",
-    "protobuf>=4.21.9",
+    "protobuf>=3.20.0",
     "PyYAML>=6.0.0",
     "croniter==1.*",
 ]


### PR DESCRIPTION
Updating the `protobuf` dependency of the Python SDK to let it be used with protobuf version 3.