### PR TITLE
feat: Apply project labels from MLP

### DIFF
--- a/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Label.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Label.java
@@ -1,0 +1,3 @@
+package dev.caraml.store.mlp;
+
+public record Label(String key, String value){}

--- a/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Label.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Label.java
@@ -1,3 +1,3 @@
 package dev.caraml.store.mlp;
 
-public record Label(String key, String value){}
+public record Label(String key, String value) {}

--- a/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Project.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Project.java
@@ -3,4 +3,3 @@ package dev.caraml.store.mlp;
 import java.util.List;
 
 public record Project(String name, String stream, String team, List<Label> labels) {}
-

--- a/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Project.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/mlp/Project.java
@@ -1,3 +1,6 @@
 package dev.caraml.store.mlp;
 
-public record Project(String name, String stream, String team) {}
+import java.util.List;
+
+public record Project(String name, String stream, String team, List<Label> labels) {}
+

--- a/caraml-store-registry/src/main/java/dev/caraml/store/mlp/ProjectContextProvider.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/mlp/ProjectContextProvider.java
@@ -1,5 +1,6 @@
 package dev.caraml.store.mlp;
 
+import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -28,7 +29,17 @@ public class ProjectContextProvider implements dev.caraml.store.sparkjob.Project
                   () ->
                       new IllegalArgumentException(
                           String.format("%s is not a valid MLP project", projectName)));
-      return Map.of("team", mlpProject.team(), "stream", mlpProject.stream());
+      Map<String, String> contextMap = new HashMap<>();
+      contextMap.put("team", mlpProject.team());
+      contextMap.put("stream", mlpProject.stream());
+
+      for (Label label : mlpProject.labels()) {
+        if (check_validity(label.key()) && check_validity(label.value())){
+          contextMap.put(label.key(), label.value());
+        }
+      }
+
+      return contextMap;
     } catch (RuntimeException e) {
       log.warn(
           String.format(
@@ -36,5 +47,13 @@ public class ProjectContextProvider implements dev.caraml.store.sparkjob.Project
               projectName, e.getMessage()));
       return Map.of("team", config.getFallbackTeam(), "stream", config.getFallbackStream());
     }
+  }
+
+  public boolean check_validity(String input){
+    // Define the regular expression pattern
+    String regex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$";
+
+    // Check if the input string matches the regular expression and length is less than 64
+    return input.length() < 64 && input.matches(regex);
   }
 }

--- a/caraml-store-registry/src/main/java/dev/caraml/store/mlp/ProjectContextProvider.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/mlp/ProjectContextProvider.java
@@ -34,7 +34,7 @@ public class ProjectContextProvider implements dev.caraml.store.sparkjob.Project
       contextMap.put("stream", mlpProject.stream());
 
       for (Label label : mlpProject.labels()) {
-        if (check_validity(label.key()) && check_validity(label.value())){
+        if (check_validity(label.key()) && check_validity(label.value())) {
           contextMap.put(label.key(), label.value());
         }
       }
@@ -49,7 +49,7 @@ public class ProjectContextProvider implements dev.caraml.store.sparkjob.Project
     }
   }
 
-  public boolean check_validity(String input){
+  public boolean check_validity(String input) {
     // Define the regular expression pattern
     String regex = "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$";
 

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
@@ -6,8 +6,6 @@ import dev.caraml.store.sparkjob.crd.SparkApplicationSpec;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class JobTemplateRenderer {
 

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
@@ -3,7 +3,6 @@ package dev.caraml.store.sparkjob;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.caraml.store.sparkjob.crd.SparkApplicationSpec;
-
 import java.util.Map;
 
 public class JobTemplateRenderer {
@@ -18,7 +17,7 @@ public class JobTemplateRenderer {
         renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
       }
       // replace all unsubstituted label values with empty string
-      renderedTemplate = renderedTemplate.replaceAll("\\$\\{.+\\}$", "");
+      renderedTemplate = renderedTemplate.replaceAll("\\$\\{(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])\\}", "");
       return mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
@@ -17,7 +17,8 @@ public class JobTemplateRenderer {
         renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
       }
       // replace all unsubstituted label values with empty string
-      renderedTemplate = renderedTemplate.replaceAll("\\$\\{(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])\\}", "");
+      renderedTemplate =
+          renderedTemplate.replaceAll("\\$\\{(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])\\}", "");
       return mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
@@ -3,7 +3,7 @@ package dev.caraml.store.sparkjob;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.caraml.store.sparkjob.crd.SparkApplicationSpec;
-import java.util.HashMap;
+
 import java.util.Map;
 
 public class JobTemplateRenderer {
@@ -11,22 +11,15 @@ public class JobTemplateRenderer {
   public SparkApplicationSpec render(
       SparkApplicationSpec templateSpec, Map<String, String> context) {
     ObjectMapper mapper = new ObjectMapper();
-    HashMap<String, String> unusedLabels = new HashMap<>();
     try {
-      String oldRenderedTemplate;
       String renderedTemplate = mapper.writeValueAsString(templateSpec);
       for (String key : context.keySet()) {
         String value = context.get(key);
-        oldRenderedTemplate = renderedTemplate;
         renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
-        // nothing got replaced
-        if (renderedTemplate.equals(oldRenderedTemplate)) unusedLabels.put(key, value);
       }
-      SparkApplicationSpec renderedSpecObject =
-          mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
-      renderedSpecObject.getDriver().getLabels().putAll(unusedLabels);
-      renderedSpecObject.getExecutor().getLabels().putAll(unusedLabels);
-      return renderedSpecObject;
+      // replace all unsubstituted label values with empty string
+      renderedTemplate = renderedTemplate.replaceAll("\\$\\{.+\\}$", "");
+      return mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
@@ -3,22 +3,34 @@ package dev.caraml.store.sparkjob;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.caraml.store.sparkjob.crd.SparkApplicationSpec;
+
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class JobTemplateRenderer {
 
-  public SparkApplicationSpec render(
-      SparkApplicationSpec templateSpec, Map<String, String> context) {
-    ObjectMapper mapper = new ObjectMapper();
-    try {
-      String renderedTemplate = mapper.writeValueAsString(templateSpec);
-      for (String key : context.keySet()) {
-        String value = context.get(key);
-        renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
-      }
-      return mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
-    } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
+    public SparkApplicationSpec render(
+            SparkApplicationSpec templateSpec, Map<String, String> context) {
+        ObjectMapper mapper = new ObjectMapper();
+        HashMap<String, String> unusedLabels = new HashMap<>();
+        try {
+            String oldRenderedTemplate;
+            String renderedTemplate = mapper.writeValueAsString(templateSpec);
+            for (String key : context.keySet()) {
+                String value = context.get(key);
+                oldRenderedTemplate = renderedTemplate;
+                renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
+                // nothing got replaced
+                if (renderedTemplate.equals(oldRenderedTemplate)) unusedLabels.put(key, value);
+            }
+            SparkApplicationSpec renderedSpecObject = mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
+            renderedSpecObject.getDriver().getLabels().putAll(unusedLabels);
+            renderedSpecObject.getExecutor().getLabels().putAll(unusedLabels);
+            return renderedSpecObject;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
-  }
 }

--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/JobTemplateRenderer.java
@@ -3,32 +3,32 @@ package dev.caraml.store.sparkjob;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.caraml.store.sparkjob.crd.SparkApplicationSpec;
-
 import java.util.HashMap;
 import java.util.Map;
 
 public class JobTemplateRenderer {
 
-    public SparkApplicationSpec render(
-            SparkApplicationSpec templateSpec, Map<String, String> context) {
-        ObjectMapper mapper = new ObjectMapper();
-        HashMap<String, String> unusedLabels = new HashMap<>();
-        try {
-            String oldRenderedTemplate;
-            String renderedTemplate = mapper.writeValueAsString(templateSpec);
-            for (String key : context.keySet()) {
-                String value = context.get(key);
-                oldRenderedTemplate = renderedTemplate;
-                renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
-                // nothing got replaced
-                if (renderedTemplate.equals(oldRenderedTemplate)) unusedLabels.put(key, value);
-            }
-            SparkApplicationSpec renderedSpecObject = mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
-            renderedSpecObject.getDriver().getLabels().putAll(unusedLabels);
-            renderedSpecObject.getExecutor().getLabels().putAll(unusedLabels);
-            return renderedSpecObject;
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+  public SparkApplicationSpec render(
+      SparkApplicationSpec templateSpec, Map<String, String> context) {
+    ObjectMapper mapper = new ObjectMapper();
+    HashMap<String, String> unusedLabels = new HashMap<>();
+    try {
+      String oldRenderedTemplate;
+      String renderedTemplate = mapper.writeValueAsString(templateSpec);
+      for (String key : context.keySet()) {
+        String value = context.get(key);
+        oldRenderedTemplate = renderedTemplate;
+        renderedTemplate = renderedTemplate.replaceAll(String.format("\\$\\{%s}", key), value);
+        // nothing got replaced
+        if (renderedTemplate.equals(oldRenderedTemplate)) unusedLabels.put(key, value);
+      }
+      SparkApplicationSpec renderedSpecObject =
+          mapper.readValue(renderedTemplate, SparkApplicationSpec.class);
+      renderedSpecObject.getDriver().getLabels().putAll(unusedLabels);
+      renderedSpecObject.getExecutor().getLabels().putAll(unusedLabels);
+      return renderedSpecObject;
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
     }
+  }
 }

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobTemplateRendererTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobTemplateRendererTest.java
@@ -39,7 +39,8 @@ class JobTemplateRendererTest {
     JobTemplateRenderer renderer = new JobTemplateRenderer();
     SparkApplicationSpec renderedSpec =
         renderer.render(
-            applicationSpec, Map.of("project", "some_project", "featureTable", "some_table", "team-id", "abc"));
+            applicationSpec,
+            Map.of("project", "some_project", "featureTable", "some_table", "team-id", "abc"));
     V1PodAffinityTerm renderedPodAffinityTerm =
         renderedSpec
             .getExecutor()


### PR DESCRIPTION
### Summary
* caraml-store-registry does not apply MLP project `labels` 
* This PR modifies the renderer to substitute the values of labels found in the configuration that were not found in MLP project `labels` field.