### PR TITLE
Enable scheduling for caraml store registry

### DIFF
--- a/buildSrc/src/main/groovy/caraml.common.gradle
+++ b/buildSrc/src/main/groovy/caraml.common.gradle
@@ -5,14 +5,14 @@ plugins {
 version = '0.0.0-SNAPSHOT'
 gitVersioning.apply {
     refs {
-        describeTagPattern = "v(?<version>.*)"
+        describeTagPattern = "^v(?<version>.*)"
         branch('main') {
             version = '${describe.tag.version}-build.${describe.distance}-${commit.short}'
         }
         branch('.+') {
             version = '${ref}-snapshot'
         }
-        tag('v(?<version>.*)') {
+        tag('^v(?<version>.*)') {
             version = '${ref.version}'
         }
     }

--- a/caraml-store-registry/src/main/java/dev/caraml/store/CaraMLRegistry.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/CaraMLRegistry.java
@@ -2,8 +2,10 @@ package dev.caraml.store;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CaraMLRegistry {
 
   public static void main(String[] args) {


### PR DESCRIPTION
Scheduling wasn't enabled on CaraML Registry service, which resulted in MLP project cache not being refreshed as intended.

Also fixed a bug where the version is not properly determined due to mistake in regex.