### PR TITLE
Upgrade Google BigTable client

### DIFF
--- a/caraml-store-serving/build.gradle
+++ b/caraml-store-serving/build.gradle
@@ -4,11 +4,12 @@ plugins {
 
 dependencies {
     implementation project(':caraml-store-protobuf')
-    implementation 'com.google.guava:guava:26.0-jre'
+    implementation 'com.google.guava:guava:33.2.1-jre'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'org.apache.avro:avro:1.10.2'
-    implementation 'com.google.cloud:google-cloud-bigtable:2.19.1'
-    implementation 'com.google.cloud:google-cloud-bigtable-bom:2.19.1'
+    implementation platform('com.google.cloud:libraries-bom:26.43.0')
+    implementation 'com.google.cloud:google-cloud-bigtable:2.40.0'
+    implementation 'commons-codec:commons-codec:1.17.1'
     implementation 'io.lettuce:lettuce-core:6.2.0.RELEASE'
     implementation 'io.netty:netty-transport-native-epoll:4.1.52.Final:linux-x86_64'
     testImplementation project(':caraml-store-testutil')

--- a/caraml-store-spark/build.gradle
+++ b/caraml-store-spark/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation 'joda-time:joda-time:2.10.6'
     implementation "com.github.scopt:scopt_$scalaVersion:3.7.1"
     implementation 'redis.clients:jedis:4.1.1'
-    implementation('com.google.cloud.bigtable:bigtable-hbase-2.x-hadoop:1.26.3') {
+    implementation('com.google.cloud.bigtable:bigtable-hbase-2.x-hadoop:2.14.3') {
         exclude group: "org.apache.hadoop", module: "hadoop-common"
     }
     implementation "org.apache.hbase:hbase-client:$hbaseVersion"


### PR DESCRIPTION
- Upgrade dependency Google Big Table: 2.19.1 -> [2.40.0](https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/history#2400httpsgithubcomgoogleapisjava-bigtablecomparev2395v2400-2024-06-28) (2024-06-28)
- Upgrade dependency bigtable-hbase-2.x-hadoop: 1.26.3 -> [2.14.3](https://mvnrepository.com/artifact/com.google.cloud.bigtable/bigtable-hbase-2.x-hadoop/2.14.3) (2024-06-30)