### PR TITLE
feat: add HBase SDK for serving

### DIFF
--- a/caraml-store-serving/build.gradle
+++ b/caraml-store-serving/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'org.apache.avro:avro:1.10.2'
     implementation platform('com.google.cloud:libraries-bom:26.43.0')
-    implementation 'com.google.cloud:google-cloud-bigtable:2.40.0'
+    implementation 'com.google.cloud:google-cloud-bigtable:2.39.2'
+    implementation 'com.google.cloud.bigtable:bigtable-hbase-2.x:2.14.3'
     implementation 'commons-codec:commons-codec:1.17.1'
     implementation 'io.lettuce:lettuce-core:6.2.0.RELEASE'
     implementation 'io.netty:netty-transport-native-epoll:4.1.52.Final:linux-x86_64'

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BaseSchemaRegistry.java
@@ -13,6 +13,7 @@ public abstract class BaseSchemaRegistry {
   protected static String COLUMN_FAMILY = "metadata";
   protected static String QUALIFIER = "avro";
   protected static String KEY_PREFIX = "schema#";
+  public static final int SCHEMA_REFERENCE_LENGTH = 4;
 
   public static class SchemaReference {
     private final String tableName;

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BaseSchemaRegistry.java
@@ -1,0 +1,64 @@
+package dev.caraml.serving.store.bigtable;
+
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.protobuf.ByteString;
+import java.util.concurrent.ExecutionException;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+
+public abstract class BaseSchemaRegistry {
+  protected LoadingCache<SchemaReference, GenericDatumReader<GenericRecord>> cache = null;
+
+  protected static String COLUMN_FAMILY = "metadata";
+  protected static String QUALIFIER = "avro";
+  protected static String KEY_PREFIX = "schema#";
+
+  public static class SchemaReference {
+    private final String tableName;
+    private final ByteString schemaHash;
+
+    public SchemaReference(String tableName, ByteString schemaHash) {
+      this.tableName = tableName;
+      this.schemaHash = schemaHash;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public ByteString getSchemaHash() {
+      return schemaHash;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = tableName.hashCode();
+      result = 31 * result + schemaHash.hashCode();
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SchemaReference that = (SchemaReference) o;
+
+      if (!tableName.equals(that.tableName)) return false;
+      return schemaHash.equals(that.schemaHash);
+    }
+  }
+
+  public GenericDatumReader<GenericRecord> getReader(SchemaReference reference) {
+    GenericDatumReader<GenericRecord> reader;
+    try {
+      reader = this.cache.get(reference);
+    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
+      throw new RuntimeException(String.format("Unable to find Schema"), e);
+    }
+    return reader;
+  }
+
+  public abstract GenericDatumReader<GenericRecord> loadReader(SchemaReference reference);
+}

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetriever.java
@@ -161,8 +161,10 @@ public class BigTableOnlineRetriever implements SSTableOnlineRetriever<ByteStrin
       BinaryDecoder reusedDecoder,
       long timestamp)
       throws IOException {
-    ByteString schemaReferenceBytes = value.substring(0, 4);
-    byte[] featureValueBytes = value.substring(4).toByteArray();
+    ByteString schemaReferenceBytes =
+        value.substring(0, BigTableSchemaRegistry.SCHEMA_REFERENCE_LENGTH);
+    byte[] featureValueBytes =
+        value.substring(BigTableSchemaRegistry.SCHEMA_REFERENCE_LENGTH).toByteArray();
 
     BigTableSchemaRegistry.SchemaReference schemaReference =
         new BigTableSchemaRegistry.SchemaReference(tableName, schemaReferenceBytes);

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableSchemaRegistry.java
@@ -6,57 +6,14 @@ import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
-import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 
-public class BigTableSchemaRegistry {
+public class BigTableSchemaRegistry extends BaseSchemaRegistry {
   private final BigtableDataClient client;
-  private final LoadingCache<SchemaReference, GenericDatumReader<GenericRecord>> cache;
-
-  private static String COLUMN_FAMILY = "metadata";
-  private static String QUALIFIER = "avro";
-  private static String KEY_PREFIX = "schema#";
-
-  public static class SchemaReference {
-    private final String tableName;
-    private final ByteString schemaHash;
-
-    public SchemaReference(String tableName, ByteString schemaHash) {
-      this.tableName = tableName;
-      this.schemaHash = schemaHash;
-    }
-
-    public String getTableName() {
-      return tableName;
-    }
-
-    public ByteString getSchemaHash() {
-      return schemaHash;
-    }
-
-    @Override
-    public int hashCode() {
-      int result = tableName.hashCode();
-      result = 31 * result + schemaHash.hashCode();
-      return result;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      SchemaReference that = (SchemaReference) o;
-
-      if (!tableName.equals(that.tableName)) return false;
-      return schemaHash.equals(that.schemaHash);
-    }
-  }
 
   public BigTableSchemaRegistry(BigtableDataClient client) {
     this.client = client;
@@ -67,17 +24,8 @@ public class BigTableSchemaRegistry {
     cache = CacheBuilder.newBuilder().build(schemaCacheLoader);
   }
 
-  public GenericDatumReader<GenericRecord> getReader(SchemaReference reference) {
-    GenericDatumReader<GenericRecord> reader;
-    try {
-      reader = this.cache.get(reference);
-    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
-      throw new RuntimeException(String.format("Unable to find Schema"), e);
-    }
-    return reader;
-  }
-
-  private GenericDatumReader<GenericRecord> loadReader(SchemaReference reference) {
+  @Override
+  public GenericDatumReader<GenericRecord> loadReader(SchemaReference reference) {
     Row row =
         client.readRow(
             reference.getTableName(),

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableStoreConfig.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableStoreConfig.java
@@ -36,7 +36,13 @@ public class BigTableStoreConfig {
           BigtableConfiguration.configure(projectId, instanceId);
       config.set(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
 
-      Connection connection = BigtableConfiguration.connect(config);
+      Connection connection;
+      try {
+        connection = BigtableConfiguration.connect(config);
+      } catch (IllegalStateException e) {
+        throw new RuntimeException(e);
+      }
+
       return new HBaseOnlineRetriever(connection);
     }
 

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableStoreConfig.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/BigTableStoreConfig.java
@@ -30,24 +30,18 @@ public class BigTableStoreConfig {
 
   @Bean
   public OnlineRetriever getRetriever() {
-    // Using HBase SDK
-    if (isUsingHBaseSDK) {
-      org.apache.hadoop.conf.Configuration config =
-          BigtableConfiguration.configure(projectId, instanceId);
-      config.set(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
+    try {
+      // Using HBase SDK
+      if (isUsingHBaseSDK) {
+        org.apache.hadoop.conf.Configuration config =
+            BigtableConfiguration.configure(projectId, instanceId);
+        config.set(BigtableOptionsFactory.APP_PROFILE_ID_KEY, appProfileId);
 
-      Connection connection;
-      try {
-        connection = BigtableConfiguration.connect(config);
-      } catch (IllegalStateException e) {
-        throw new RuntimeException(e);
+        Connection connection = BigtableConfiguration.connect(config);
+        return new HBaseOnlineRetriever(connection);
       }
 
-      return new HBaseOnlineRetriever(connection);
-    }
-
-    // Using BigTable SDK
-    try {
+      // Using BigTable SDK
       BigtableDataSettings.Builder builder =
           BigtableDataSettings.newBuilder()
               .setProjectId(projectId)
@@ -66,6 +60,7 @@ public class BigTableStoreConfig {
       }
       BigtableDataClient client = BigtableDataClient.create(settings);
       return new BigTableOnlineRetriever(client);
+
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
@@ -1,0 +1,163 @@
+package dev.caraml.serving.store.bigtable;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Timestamp;
+import dev.caraml.serving.store.AvroFeature;
+import dev.caraml.serving.store.Feature;
+import dev.caraml.store.protobuf.serving.ServingServiceProto;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.util.Bytes;
+
+public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, Result> {
+  private final Connection client;
+  private final HBaseSchemaRegistry schemaRegistry;
+
+  public HBaseOnlineRetriever(Connection client) {
+    this.client = client;
+    this.schemaRegistry = new HBaseSchemaRegistry(client);
+  }
+
+  @Override
+  public ByteString convertEntityValueToKey(
+      ServingServiceProto.GetOnlineFeaturesRequest.EntityRow entityRow, List<String> entityNames) {
+    return ByteString.copyFrom(
+        entityNames.stream()
+            .sorted()
+            .map(entity -> entityRow.getFieldsMap().get(entity))
+            .map(this::valueToString)
+            .collect(Collectors.joining("#"))
+            .getBytes());
+  }
+
+  @Override
+  public List<List<Feature>> convertRowToFeature(
+      String tableName,
+      List<ByteString> rowKeys,
+      Map<ByteString, Result> rows,
+      List<ServingServiceProto.FeatureReference> featureReferences) {
+    BinaryDecoder reusedDecoder = DecoderFactory.get().binaryDecoder(new byte[0], null);
+
+    return rowKeys.stream()
+        .map(
+            rowKey -> {
+              if (!rows.containsKey(rowKey)) {
+                return Collections.<Feature>emptyList();
+              } else {
+                Result row = rows.get(rowKey);
+                return featureReferences.stream()
+                    .map(ServingServiceProto.FeatureReference::getFeatureTable)
+                    .distinct()
+                    .map(cf -> row.getColumnCells(cf.getBytes(), null))
+                    .filter(ls -> !ls.isEmpty())
+                    .flatMap(
+                        rowCells -> {
+                          Cell rowCell = rowCells.get(0); // Latest cell
+                          String family = Bytes.toString(rowCell.getFamilyArray());
+                          ByteString value = ByteString.copyFrom(rowCell.getValueArray());
+
+                          List<Feature> features;
+                          List<ServingServiceProto.FeatureReference> localFeatureReferences =
+                              featureReferences.stream()
+                                  .filter(
+                                      featureReference ->
+                                          featureReference.getFeatureTable().equals(family))
+                                  .collect(Collectors.toList());
+
+                          try {
+                            features =
+                                decodeFeatures(
+                                    tableName,
+                                    value,
+                                    localFeatureReferences,
+                                    reusedDecoder,
+                                    rowCell.getTimestamp());
+                          } catch (IOException e) {
+                            throw new RuntimeException("Failed to decode features from BigTable");
+                          }
+
+                          return features.stream();
+                        })
+                    .collect(Collectors.toList());
+              }
+            })
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Map<ByteString, Result> getFeaturesFromSSTable(
+      String tableName, List<ByteString> rowKeys, List<String> columnFamilies) {
+    try {
+      Table table = this.client.getTable(TableName.valueOf(tableName));
+
+      // construct query get list
+      List<Get> queryGetList = new ArrayList<>();
+      rowKeys.forEach(
+          rowKey -> {
+            Get get = new Get(rowKey.toByteArray());
+            columnFamilies.forEach(cf -> get.addFamily(cf.getBytes()));
+
+            queryGetList.add(get);
+          });
+
+      // fetch data from table
+      Result[] rows = table.get(queryGetList);
+
+      // construct result
+      Map<ByteString, Result> result = new HashMap<>();
+      Arrays.stream(rows)
+          .filter(row -> !row.isEmpty())
+          .forEach(row -> result.put(ByteString.copyFrom(row.getRow()), row));
+
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<Feature> decodeFeatures(
+      String tableName,
+      ByteString value,
+      List<ServingServiceProto.FeatureReference> featureReferences,
+      BinaryDecoder reusedDecoder,
+      long timestamp)
+      throws IOException {
+    ByteString schemaReferenceBytes = value.substring(0, 4);
+    byte[] featureValueBytes = value.substring(4).toByteArray();
+
+    HBaseSchemaRegistry.SchemaReference schemaReference =
+        new HBaseSchemaRegistry.SchemaReference(tableName, schemaReferenceBytes);
+
+    GenericDatumReader<GenericRecord> reader = this.schemaRegistry.getReader(schemaReference);
+
+    reusedDecoder = DecoderFactory.get().binaryDecoder(featureValueBytes, reusedDecoder);
+    GenericRecord record = reader.read(null, reusedDecoder);
+
+    return featureReferences.stream()
+        .map(
+            featureReference -> {
+              Object featureValue;
+              try {
+                featureValue = record.get(featureReference.getName());
+              } catch (AvroRuntimeException e) {
+                // Feature is not found in schema
+                return null;
+              }
+              return new AvroFeature(
+                  featureReference,
+                  Timestamp.newBuilder().setSeconds(timestamp / 1000).build(),
+                  Objects.requireNonNullElseGet(featureValue, Object::new));
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+}

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
@@ -17,7 +17,6 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
-import org.apache.hadoop.hbase.util.Bytes;
 
 public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, Result> {
   private final Connection client;
@@ -58,31 +57,37 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
                 return featureReferences.stream()
                     .map(ServingServiceProto.FeatureReference::getFeatureTable)
                     .distinct()
-                        .map(cf -> {
-                            List<Cell> rowCells = row.getColumnCells(cf.getBytes(), null);
-                            System.out.println("Column Family: " + cf);
-                            System.out.println("Row Cells: " + rowCells);
-                            return rowCells;
+                    .map(
+                        cf -> {
+                          List<Cell> rowCells = row.getColumnCells(cf.getBytes(), null);
+                          System.out.println("Column Family: " + cf);
+                          System.out.println("Row Cells: " + rowCells);
+                          return rowCells;
                         })
-//                    .map(cf -> row.getColumnCells(cf.getBytes(), null))
+                    //                    .map(cf -> row.getColumnCells(cf.getBytes(), null))
                     .filter(ls -> !ls.isEmpty())
                     .flatMap(
                         rowCells -> {
                           Cell rowCell = rowCells.get(0); // Latest cell
-//                          String family = Bytes.toString(rowCell.getFamilyArray());
-//                          System.out.println("rowCell: " + rowCell.toString());
-//                          ByteString value = ByteString.copyFrom(rowCell.getValueArray());
-//                          System.out.println("value: " + value);
-                            ByteBuffer valueBuffer = ByteBuffer.wrap(rowCell.getValueArray())
-                                    .position(rowCell.getValueOffset())
-                                    .limit(rowCell.getValueOffset() + rowCell.getValueLength())
-                                    .slice();
-                            ByteBuffer familyBuffer = ByteBuffer.wrap(rowCell.getFamilyArray())
-                                    .position(rowCell.getFamilyOffset())
-                                    .limit(rowCell.getFamilyOffset() + rowCell.getFamilyLength())
-                                    .slice();
-                            String family = ByteString.copyFrom(familyBuffer).toStringUtf8();
-                            ByteString value = ByteString.copyFrom(valueBuffer);
+                          //                          String family =
+                          // Bytes.toString(rowCell.getFamilyArray());
+                          //                          System.out.println("rowCell: " +
+                          // rowCell.toString());
+                          //                          ByteString value =
+                          // ByteString.copyFrom(rowCell.getValueArray());
+                          //                          System.out.println("value: " + value);
+                          ByteBuffer valueBuffer =
+                              ByteBuffer.wrap(rowCell.getValueArray())
+                                  .position(rowCell.getValueOffset())
+                                  .limit(rowCell.getValueOffset() + rowCell.getValueLength())
+                                  .slice();
+                          ByteBuffer familyBuffer =
+                              ByteBuffer.wrap(rowCell.getFamilyArray())
+                                  .position(rowCell.getFamilyOffset())
+                                  .limit(rowCell.getFamilyOffset() + rowCell.getFamilyLength())
+                                  .slice();
+                          String family = ByteString.copyFrom(familyBuffer).toStringUtf8();
+                          ByteString value = ByteString.copyFrom(valueBuffer);
 
                           List<Feature> features;
                           List<ServingServiceProto.FeatureReference> localFeatureReferences =
@@ -136,7 +141,6 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
       Arrays.stream(rows)
           .filter(row -> !row.isEmpty())
           .forEach(row -> result.put(ByteString.copyFrom(row.getRow()), row));
-
 
       return result;
     } catch (IOException e) {

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
@@ -27,6 +27,13 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
     this.schemaRegistry = new HBaseSchemaRegistry(client);
   }
 
+  /**
+   * Generate BigTable key in the form of entity values joined by #.
+   *
+   * @param entityRow Single EntityRow representation in feature retrieval call
+   * @param entityNames List of entities related to feature references in retrieval call
+   * @return
+   */
   @Override
   public ByteString convertEntityValueToKey(
       ServingServiceProto.GetOnlineFeaturesRequest.EntityRow entityRow, List<String> entityNames) {
@@ -39,6 +46,15 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
             .getBytes());
   }
 
+  /**
+   * Converts rowCell feature into @NativeFeature type, HBase specific implementation
+   *
+   * @param tableName Name of SSTable
+   * @param rowKeys List of keys of rows to retrieve
+   * @param rows Map of rowKey to Row related to it
+   * @param featureReferences List of feature references
+   * @return
+   */
   @Override
   public List<List<Feature>> convertRowToFeature(
       String tableName,
@@ -134,6 +150,15 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
     }
   }
 
+  /**
+   * @param tableName
+   * @param value
+   * @param featureReferences
+   * @param reusedDecoder
+   * @param timestamp
+   * @return
+   * @throws IOException
+   */
   private List<Feature> decodeFeatures(
       String tableName,
       ByteString value,

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
@@ -175,8 +175,10 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
       BinaryDecoder reusedDecoder,
       long timestamp)
       throws IOException {
-    ByteString schemaReferenceBytes = value.substring(0, 4);
-    byte[] featureValueBytes = value.substring(4).toByteArray();
+    ByteString schemaReferenceBytes =
+        value.substring(0, HBaseSchemaRegistry.SCHEMA_REFERENCE_LENGTH);
+    byte[] featureValueBytes =
+        value.substring(HBaseSchemaRegistry.SCHEMA_REFERENCE_LENGTH).toByteArray();
 
     HBaseSchemaRegistry.SchemaReference schemaReference =
         new HBaseSchemaRegistry.SchemaReference(tableName, schemaReferenceBytes);

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseOnlineRetriever.java
@@ -57,25 +57,11 @@ public class HBaseOnlineRetriever implements SSTableOnlineRetriever<ByteString, 
                 return featureReferences.stream()
                     .map(ServingServiceProto.FeatureReference::getFeatureTable)
                     .distinct()
-                    .map(
-                        cf -> {
-                          List<Cell> rowCells = row.getColumnCells(cf.getBytes(), null);
-                          System.out.println("Column Family: " + cf);
-                          System.out.println("Row Cells: " + rowCells);
-                          return rowCells;
-                        })
-                    //                    .map(cf -> row.getColumnCells(cf.getBytes(), null))
+                    .map(cf -> row.getColumnCells(cf.getBytes(), null))
                     .filter(ls -> !ls.isEmpty())
                     .flatMap(
                         rowCells -> {
                           Cell rowCell = rowCells.get(0); // Latest cell
-                          //                          String family =
-                          // Bytes.toString(rowCell.getFamilyArray());
-                          //                          System.out.println("rowCell: " +
-                          // rowCell.toString());
-                          //                          ByteString value =
-                          // ByteString.copyFrom(rowCell.getValueArray());
-                          //                          System.out.println("value: " + value);
                           ByteBuffer valueBuffer =
                               ByteBuffer.wrap(rowCell.getValueArray())
                                   .position(rowCell.getValueOffset())

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
@@ -16,7 +16,6 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Table;
-import org.apache.hadoop.hbase.util.Bytes;
 
 public class HBaseSchemaRegistry {
   private final Connection hbaseClient;
@@ -96,12 +95,13 @@ public class HBaseSchemaRegistry {
 
       Cell last = result.getColumnLatestCell(COLUMN_FAMILY.getBytes(), QUALIFIER.getBytes());
       if (last == null) {
-          throw new RuntimeException("Schema not found");
+        throw new RuntimeException("Schema not found");
       }
-      ByteBuffer schemaBuffer = ByteBuffer.wrap(last.getValueArray())
-          .position(last.getValueOffset())
-          .limit(last.getValueOffset() + last.getValueLength())
-          .slice();
+      ByteBuffer schemaBuffer =
+          ByteBuffer.wrap(last.getValueArray())
+              .position(last.getValueOffset())
+              .limit(last.getValueOffset() + last.getValueLength())
+              .slice();
       Schema schema = new Schema.Parser().parse(ByteString.copyFrom(schemaBuffer).toStringUtf8());
       return new GenericDatumReader<>(schema);
     } catch (IOException e) {

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
@@ -46,15 +46,18 @@ public class HBaseSchemaRegistry extends BaseSchemaRegistry {
         // NOTE: this should never happen
         throw new RuntimeException("Schema not found");
       }
-      ByteBuffer schemaBuffer =
-          ByteBuffer.wrap(last.getValueArray())
-              .position(last.getValueOffset())
-              .limit(last.getValueOffset() + last.getValueLength())
-              .slice();
+      ByteBuffer schemaBuffer = GetValueByteBufferFromRowCell(last);
       Schema schema = new Schema.Parser().parse(ByteString.copyFrom(schemaBuffer).toStringUtf8());
       return new GenericDatumReader<>(schema);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static ByteBuffer GetValueByteBufferFromRowCell(Cell cell) {
+    return ByteBuffer.wrap(cell.getValueArray())
+        .position(cell.getValueOffset())
+        .limit(cell.getValueOffset() + cell.getValueLength())
+        .slice();
   }
 }

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
@@ -95,6 +95,7 @@ public class HBaseSchemaRegistry {
 
       Cell last = result.getColumnLatestCell(COLUMN_FAMILY.getBytes(), QUALIFIER.getBytes());
       if (last == null) {
+        // NOTE: this should never happen
         throw new RuntimeException("Schema not found");
       }
       ByteBuffer schemaBuffer =

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
@@ -1,0 +1,103 @@
+package dev.caraml.serving.store.bigtable;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+
+public class HBaseSchemaRegistry {
+  private final Connection hbaseClient;
+  private final LoadingCache<SchemaReference, GenericDatumReader<GenericRecord>> cache;
+
+  private static String COLUMN_FAMILY = "metadata";
+  private static String QUALIFIER = "avro";
+  private static String KEY_PREFIX = "schema#";
+
+  public static class SchemaReference {
+    private final String tableName;
+    private final ByteString schemaHash;
+
+    public SchemaReference(String tableName, ByteString schemaHash) {
+      this.tableName = tableName;
+      this.schemaHash = schemaHash;
+    }
+
+    public String getTableName() {
+      return tableName;
+    }
+
+    public ByteString getSchemaHash() {
+      return schemaHash;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = tableName.hashCode();
+      result = 31 * result + schemaHash.hashCode();
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      SchemaReference that = (SchemaReference) o;
+
+      if (!tableName.equals(that.tableName)) return false;
+      return schemaHash.equals(that.schemaHash);
+    }
+  }
+
+  public HBaseSchemaRegistry(Connection hbaseClient) {
+    this.hbaseClient = hbaseClient;
+
+    CacheLoader<SchemaReference, GenericDatumReader<GenericRecord>> schemaCacheLoader =
+        CacheLoader.from(this::loadReader);
+
+    cache = CacheBuilder.newBuilder().build(schemaCacheLoader);
+  }
+
+  public GenericDatumReader<GenericRecord> getReader(SchemaReference reference) {
+    GenericDatumReader<GenericRecord> reader;
+    try {
+      reader = this.cache.get(reference);
+    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
+      throw new RuntimeException(String.format("Unable to find Schema"), e);
+    }
+    return reader;
+  }
+
+  private GenericDatumReader<GenericRecord> loadReader(SchemaReference reference) {
+    try {
+      Table table = this.hbaseClient.getTable(TableName.valueOf(reference.getTableName()));
+
+      byte[] rowKey =
+          ByteString.copyFrom(KEY_PREFIX.getBytes())
+              .concat(reference.getSchemaHash())
+              .toByteArray();
+      Get query = new Get(rowKey);
+      query.addColumn(COLUMN_FAMILY.getBytes(), QUALIFIER.getBytes());
+
+      Result result = table.get(query);
+
+      Cell last = result.getColumnLatestCell(COLUMN_FAMILY.getBytes(), QUALIFIER.getBytes());
+      Schema schema = new Schema.Parser().parse(Bytes.toString(last.getValueArray()));
+      return new GenericDatumReader<>(schema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseSchemaRegistry.java
@@ -2,11 +2,9 @@ package dev.caraml.serving.store.bigtable;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
@@ -17,49 +15,8 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Table;
 
-public class HBaseSchemaRegistry {
+public class HBaseSchemaRegistry extends BaseSchemaRegistry {
   private final Connection hbaseClient;
-  private final LoadingCache<SchemaReference, GenericDatumReader<GenericRecord>> cache;
-
-  private static String COLUMN_FAMILY = "metadata";
-  private static String QUALIFIER = "avro";
-  private static String KEY_PREFIX = "schema#";
-
-  public static class SchemaReference {
-    private final String tableName;
-    private final ByteString schemaHash;
-
-    public SchemaReference(String tableName, ByteString schemaHash) {
-      this.tableName = tableName;
-      this.schemaHash = schemaHash;
-    }
-
-    public String getTableName() {
-      return tableName;
-    }
-
-    public ByteString getSchemaHash() {
-      return schemaHash;
-    }
-
-    @Override
-    public int hashCode() {
-      int result = tableName.hashCode();
-      result = 31 * result + schemaHash.hashCode();
-      return result;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-
-      SchemaReference that = (SchemaReference) o;
-
-      if (!tableName.equals(that.tableName)) return false;
-      return schemaHash.equals(that.schemaHash);
-    }
-  }
 
   public HBaseSchemaRegistry(Connection hbaseClient) {
     this.hbaseClient = hbaseClient;
@@ -70,17 +27,8 @@ public class HBaseSchemaRegistry {
     cache = CacheBuilder.newBuilder().build(schemaCacheLoader);
   }
 
-  public GenericDatumReader<GenericRecord> getReader(SchemaReference reference) {
-    GenericDatumReader<GenericRecord> reader;
-    try {
-      reader = this.cache.get(reference);
-    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
-      throw new RuntimeException(String.format("Unable to find Schema"), e);
-    }
-    return reader;
-  }
-
-  private GenericDatumReader<GenericRecord> loadReader(SchemaReference reference) {
+  @Override
+  public GenericDatumReader<GenericRecord> loadReader(SchemaReference reference) {
     try {
       Table table = this.hbaseClient.getTable(TableName.valueOf(reference.getTableName()));
 

--- a/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseStoreConfig.java
+++ b/caraml-store-serving/src/main/java/dev/caraml/serving/store/bigtable/HBaseStoreConfig.java
@@ -1,0 +1,39 @@
+package dev.caraml.serving.store.bigtable;
+
+import dev.caraml.serving.store.OnlineRetriever;
+import java.io.IOException;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "caraml.store.hbase")
+@ConditionalOnProperty(prefix = "caraml.store", name = "active", havingValue = "hbase")
+@Getter
+@Setter
+public class HBaseStoreConfig {
+  private String zookeeperQuorum;
+  private String zookeeperClientPort;
+
+  @Bean
+  public OnlineRetriever getRetriever() {
+    org.apache.hadoop.conf.Configuration conf;
+    conf = HBaseConfiguration.create();
+    conf.set("hbase.zookeeper.quorum", zookeeperQuorum);
+    conf.set("hbase.zookeeper.property.clientPort", zookeeperClientPort);
+    Connection connection;
+    try {
+      connection = ConnectionFactory.createConnection(conf);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return new HBaseOnlineRetriever(connection);
+  }
+}

--- a/caraml-store-serving/src/main/resources/application.yaml
+++ b/caraml-store-serving/src/main/resources/application.yaml
@@ -76,6 +76,7 @@ caraml:
       enableClientSideMetrics: false
       # Timeout configuration for BigTable client. Set 0 to use the default client configuration.
       timeoutMs: 0
+      isUsingHBaseSDK: true
 
 grpc:
   server:

--- a/caraml-store-serving/src/main/resources/application.yaml
+++ b/caraml-store-serving/src/main/resources/application.yaml
@@ -33,41 +33,41 @@ caraml:
       maxExpectedCount: 150
 
   store:
-    # Active store. Possible values: [redisCluster, redis, bigtable]
+    # Active store. Possible values: [redisCluster, redis, bigtable, hbase]
     active: redis
-
-    redis:
-      host: localhost
-      port: 6379
-      password: ""
-      ssl: false
-
-    redisCluster:
-      # Connection string specifies the host:port of Redis instances in the redis cluster.
-      connectionString: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
-      # Password authentication. Empty string if password is not set.
-      password: ""
-      readFrom: MASTER
-      # Redis operation timeout in ISO-8601 format
-      timeout: PT0.5S
-#      # Uncomment to customize netty behaviour
-#      tcp:
-#        # Epoll Channel Option: TCP_KEEPIDLE
-#        keepIdle: 15
-#        # Epoll Channel Option: TCP_KEEPINTVL
-#        keepInterval: 5
-#        # Epoll Channel Option: TCP_KEEPCNT
-#        keepConnection: 3
-#        # Epoll Channel Option: TCP_USER_TIMEOUT
-#        userConnection: 60000
-#      # Uncomment to customize redis cluster topology refresh config
-#      topologyRefresh:
-#        # enable adaptive topology refresh from all triggers : MOVED_REDIRECT, ASK_REDIRECT, PERSISTENT_RECONNECTS, UNKNOWN_NODE (since 5.1), and UNCOVERED_SLOT (since 5.2) (see also reconnect attempts for the reconnect trigger)
-#        enableAllAdaptiveTriggerRefresh: true
-#        # enable periodic refresh
-#        enablePeriodicRefresh: false
-#        # topology refresh period in seconds
-#        refreshPeriodSecond: 30
+    #
+    #    redis:
+    #      host: localhost
+    #      port: 6379
+    #      password: ""
+    #      ssl: false
+    #
+    #    redisCluster:
+    #      # Connection string specifies the host:port of Redis instances in the redis cluster.
+    #      connectionString: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
+    #      # Password authentication. Empty string if password is not set.
+    #      password: ""
+    #      readFrom: MASTER
+    #      # Redis operation timeout in ISO-8601 format
+    #      timeout: PT0.5S
+    #      # Uncomment to customize netty behaviour
+    #      tcp:
+    #        # Epoll Channel Option: TCP_KEEPIDLE
+    #        keepIdle: 15
+    #        # Epoll Channel Option: TCP_KEEPINTVL
+    #        keepInterval: 5
+    #        # Epoll Channel Option: TCP_KEEPCNT
+    #        keepConnection: 3
+    #        # Epoll Channel Option: TCP_USER_TIMEOUT
+    #        userConnection: 60000
+    #      # Uncomment to customize redis cluster topology refresh config
+    #      topologyRefresh:
+    #        # enable adaptive topology refresh from all triggers : MOVED_REDIRECT, ASK_REDIRECT, PERSISTENT_RECONNECTS, UNKNOWN_NODE (since 5.1), and UNCOVERED_SLOT (since 5.2) (see also reconnect attempts for the reconnect trigger)
+    #        enableAllAdaptiveTriggerRefresh: true
+    #        # enable periodic refresh
+    #        enablePeriodicRefresh: false
+    #        # topology refresh period in seconds
+    #        refreshPeriodSecond: 30
 
     bigtable:
       projectId: gcp-project-name
@@ -77,6 +77,10 @@ caraml:
       # Timeout configuration for BigTable client. Set 0 to use the default client configuration.
       timeoutMs: 0
       isUsingHBaseSDK: true
+
+    hbase:
+      zookeeperQuorum: 127.0.0.1
+      zookeeperClientPort: 2181
 
 grpc:
   server:

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetrieverTest.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetrieverTest.java
@@ -80,7 +80,9 @@ public class BigTableOnlineRetrieverTest {
                 .setInstanceId(INSTANCE_ID)
                 .build());
     Configuration config = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
-    config.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + bigtableEmulator.getMappedPort(BIGTABLE_EMULATOR_PORT));
+    config.set(
+        BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY,
+        "localhost:" + bigtableEmulator.getMappedPort(BIGTABLE_EMULATOR_PORT));
     hbaseClient = BigtableConfiguration.connect(config);
     ingestData();
   }
@@ -237,17 +239,17 @@ public class BigTableOnlineRetrieverTest {
   }
 
   @Test
-  public void shouldRetrieveFeaturesSuccessfullyWhenUsingHbase(){
+  public void shouldRetrieveFeaturesSuccessfullyWhenUsingHbase() {
     HBaseOnlineRetriever retriever = new HBaseOnlineRetriever(hbaseClient);
     List<FeatureReference> featureReferences =
-            Stream.of("trip_cost", "trip_distance")
-                    .map(f -> FeatureReference.newBuilder().setFeatureTable("rides").setName(f).build())
-                    .toList();
+        Stream.of("trip_cost", "trip_distance")
+            .map(f -> FeatureReference.newBuilder().setFeatureTable("rides").setName(f).build())
+            .toList();
     List<String> entityNames = List.of("driver");
     List<EntityRow> entityRows =
-            List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
+        List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
     List<List<Feature>> featuresForRows =
-            retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
+        retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
     assertEquals(1, featuresForRows.size());
     List<Feature> features = featuresForRows.get(0);
     assertEquals(2, features.size());
@@ -255,20 +257,19 @@ public class BigTableOnlineRetrieverTest {
     assertEquals(featureReferences.get(0), features.get(0).getFeatureReference());
     assertEquals(3.5, features.get(1).getFeatureValue(ValueType.Enum.DOUBLE).getDoubleVal());
     assertEquals(featureReferences.get(1), features.get(1).getFeatureReference());
-
   }
 
   @Test
   public void shouldFilterOutMissingFeatureRefUsingHbase() {
-    BigTableOnlineRetriever retriever = new BigTableOnlineRetriever(client);
+    HBaseOnlineRetriever retriever = new HBaseOnlineRetriever(hbaseClient);
     List<FeatureReference> featureReferences =
-            List.of(
-                    FeatureReference.newBuilder().setFeatureTable("rides").setName("not_exists").build());
+        List.of(
+            FeatureReference.newBuilder().setFeatureTable("rides").setName("not_exists").build());
     List<String> entityNames = List.of("driver");
     List<EntityRow> entityRows =
-            List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
+        List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
     List<List<Feature>> features =
-            retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
+        retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
     assertEquals(1, features.size());
     assertEquals(0, features.get(0).size());
   }

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetrieverTest.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/BigTableOnlineRetrieverTest.java
@@ -8,6 +8,8 @@ import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.ByteString;
 import dev.caraml.serving.store.Feature;
@@ -26,6 +28,8 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Connection;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -40,6 +44,7 @@ public class BigTableOnlineRetrieverTest {
   static final Integer BIGTABLE_EMULATOR_PORT = 8086;
   static final String FEAST_PROJECT = "default";
   static BigtableDataClient client;
+  static Connection hbaseClient;
   static BigtableTableAdminClient adminClient;
 
   @Container
@@ -74,6 +79,9 @@ public class BigTableOnlineRetrieverTest {
                 .setProjectId(PROJECT_ID)
                 .setInstanceId(INSTANCE_ID)
                 .build());
+    Configuration config = BigtableConfiguration.configure(PROJECT_ID, INSTANCE_ID);
+    config.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + bigtableEmulator.getMappedPort(BIGTABLE_EMULATOR_PORT));
+    hbaseClient = BigtableConfiguration.connect(config);
     ingestData();
   }
 
@@ -224,6 +232,43 @@ public class BigTableOnlineRetrieverTest {
         List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
     List<List<Feature>> features =
         retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
+    assertEquals(1, features.size());
+    assertEquals(0, features.get(0).size());
+  }
+
+  @Test
+  public void shouldRetrieveFeaturesSuccessfullyWhenUsingHbase(){
+    HBaseOnlineRetriever retriever = new HBaseOnlineRetriever(hbaseClient);
+    List<FeatureReference> featureReferences =
+            Stream.of("trip_cost", "trip_distance")
+                    .map(f -> FeatureReference.newBuilder().setFeatureTable("rides").setName(f).build())
+                    .toList();
+    List<String> entityNames = List.of("driver");
+    List<EntityRow> entityRows =
+            List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
+    List<List<Feature>> featuresForRows =
+            retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
+    assertEquals(1, featuresForRows.size());
+    List<Feature> features = featuresForRows.get(0);
+    assertEquals(2, features.size());
+    assertEquals(5L, features.get(0).getFeatureValue(ValueType.Enum.INT64).getInt64Val());
+    assertEquals(featureReferences.get(0), features.get(0).getFeatureReference());
+    assertEquals(3.5, features.get(1).getFeatureValue(ValueType.Enum.DOUBLE).getDoubleVal());
+    assertEquals(featureReferences.get(1), features.get(1).getFeatureReference());
+
+  }
+
+  @Test
+  public void shouldFilterOutMissingFeatureRefUsingHbase() {
+    BigTableOnlineRetriever retriever = new BigTableOnlineRetriever(client);
+    List<FeatureReference> featureReferences =
+            List.of(
+                    FeatureReference.newBuilder().setFeatureTable("rides").setName("not_exists").build());
+    List<String> entityNames = List.of("driver");
+    List<EntityRow> entityRows =
+            List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
+    List<List<Feature>> features =
+            retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
     assertEquals(1, features.size());
     assertEquals(0, features.get(0).size());
   }

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
@@ -1,0 +1,63 @@
+package dev.caraml.serving.store.bigtable;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Arrays;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+public class GenericHbase2Container extends GenericContainer<GenericHbase2Container> {
+
+  private final String hostName;
+  private final Configuration hbase2Configuration = HBaseConfiguration.create();
+
+  public GenericHbase2Container() {
+    super(DockerImageName.parse("jcjabouille/hbase-standalone:2.4.9"));
+    {
+      try {
+        hostName = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    int masterPort = 16010;
+    addExposedPort(masterPort);
+    int regionPort = 16011;
+    addExposedPort(regionPort);
+    addExposedPort(2181);
+
+    withCreateContainerCmdModifier(
+        cmd -> {
+          cmd.withHostName(hostName);
+        });
+
+    waitingFor(Wait.forLogMessage(".*running regionserver.*", 1));
+    withStartupTimeout(Duration.ofMinutes(10));
+
+    withEnv("HBASE_MASTER_PORT", Integer.toString(masterPort));
+    withEnv("HBASE_REGION_PORT", Integer.toString(regionPort));
+    setPortBindings(
+        Arrays.asList(
+            String.format("%d:%d", masterPort, masterPort),
+            String.format("%d:%d", regionPort, regionPort)));
+  }
+
+  @Override
+  protected void doStart() {
+    super.doStart();
+
+    hbase2Configuration.set("hbase.client.pause", "200");
+    hbase2Configuration.set("hbase.client.retries.number", "10");
+    hbase2Configuration.set("hbase.rpc.timeout", "3000");
+    hbase2Configuration.set("hbase.client.operation.timeout", "3000");
+    hbase2Configuration.set("hbase.client.scanner.timeout.period", "10000");
+    hbase2Configuration.set("zookeeper.session.timeout", "10000");
+    hbase2Configuration.set("hbase.zookeeper.quorum", "localhost");
+    hbase2Configuration.set(
+        "hbase.zookeeper.property.clientPort", Integer.toString(getMappedPort(2181)));
+  }
+}

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
@@ -13,7 +13,7 @@ import org.testcontainers.utility.DockerImageName;
 public class GenericHbase2Container extends GenericContainer<GenericHbase2Container> {
 
   private final String hostName;
-  private final Configuration hbase2Configuration = HBaseConfiguration.create();
+  public final Configuration hbase2Configuration = HBaseConfiguration.create();
 
   public GenericHbase2Container() {
     super(DockerImageName.parse("jcjabouille/hbase-standalone:2.4.9"));
@@ -40,10 +40,13 @@ public class GenericHbase2Container extends GenericContainer<GenericHbase2Contai
 
     withEnv("HBASE_MASTER_PORT", Integer.toString(masterPort));
     withEnv("HBASE_REGION_PORT", Integer.toString(regionPort));
-    setPortBindings(
-        Arrays.asList(
-            String.format("%d:%d", masterPort, masterPort),
-            String.format("%d:%d", regionPort, regionPort)));
+//    setPortBindings(
+//        Arrays.asList(
+//            String.format("%d:%d", masterPort, masterPort),
+//            String.format("%d:%d", regionPort, regionPort)));
+
+    // Set network mode to host
+    withNetworkMode("host");
   }
 
   @Override

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
@@ -3,7 +3,6 @@ package dev.caraml.serving.store.bigtable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
-import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.testcontainers.containers.GenericContainer;
@@ -40,10 +39,10 @@ public class GenericHbase2Container extends GenericContainer<GenericHbase2Contai
 
     withEnv("HBASE_MASTER_PORT", Integer.toString(masterPort));
     withEnv("HBASE_REGION_PORT", Integer.toString(regionPort));
-//    setPortBindings(
-//        Arrays.asList(
-//            String.format("%d:%d", masterPort, masterPort),
-//            String.format("%d:%d", regionPort, regionPort)));
+    //    setPortBindings(
+    //        Arrays.asList(
+    //            String.format("%d:%d", masterPort, masterPort),
+    //            String.format("%d:%d", regionPort, regionPort)));
 
     // Set network mode to host
     withNetworkMode("host");

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/GenericHbase2Container.java
@@ -1,7 +1,5 @@
 package dev.caraml.serving.store.bigtable;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.Duration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -11,41 +9,21 @@ import org.testcontainers.utility.DockerImageName;
 
 public class GenericHbase2Container extends GenericContainer<GenericHbase2Container> {
 
-  private final String hostName;
+  private final String hostName = "hbase-docker";
   public final Configuration hbase2Configuration = HBaseConfiguration.create();
 
   public GenericHbase2Container() {
-    super(DockerImageName.parse("jcjabouille/hbase-standalone:2.4.9"));
-    {
-      try {
-        hostName = InetAddress.getLocalHost().getHostName();
-      } catch (UnknownHostException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    int masterPort = 16010;
-    addExposedPort(masterPort);
-    int regionPort = 16011;
-    addExposedPort(regionPort);
-    addExposedPort(2181);
-
+    super(DockerImageName.parse("dajobe/hbase:latest"));
     withCreateContainerCmdModifier(
         cmd -> {
           cmd.withHostName(hostName);
         });
 
-    waitingFor(Wait.forLogMessage(".*running regionserver.*", 1));
-    withStartupTimeout(Duration.ofMinutes(10));
-
-    withEnv("HBASE_MASTER_PORT", Integer.toString(masterPort));
-    withEnv("HBASE_REGION_PORT", Integer.toString(regionPort));
-    //    setPortBindings(
-    //        Arrays.asList(
-    //            String.format("%d:%d", masterPort, masterPort),
-    //            String.format("%d:%d", regionPort, regionPort)));
-
-    // Set network mode to host
     withNetworkMode("host");
+    withEnv("HBASE_DOCKER_HOSTNAME", "127.0.0.1");
+
+    waitingFor(Wait.forLogMessage(".*master.HMaster: Master has completed initialization.*", 1));
+    withStartupTimeout(Duration.ofMinutes(10));
   }
 
   @Override
@@ -56,10 +34,10 @@ public class GenericHbase2Container extends GenericContainer<GenericHbase2Contai
     hbase2Configuration.set("hbase.client.retries.number", "10");
     hbase2Configuration.set("hbase.rpc.timeout", "3000");
     hbase2Configuration.set("hbase.client.operation.timeout", "3000");
+    hbase2Configuration.set("hbase.rpc.timeout", "3000");
     hbase2Configuration.set("hbase.client.scanner.timeout.period", "10000");
     hbase2Configuration.set("zookeeper.session.timeout", "10000");
     hbase2Configuration.set("hbase.zookeeper.quorum", "localhost");
-    hbase2Configuration.set(
-        "hbase.zookeeper.property.clientPort", Integer.toString(getMappedPort(2181)));
+    hbase2Configuration.set("hbase.zookeeper.property.clientPort", "2181");
   }
 }

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
@@ -1,0 +1,209 @@
+package dev.caraml.serving.store.bigtable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.hash.Hashing;
+import dev.caraml.serving.store.Feature;
+import dev.caraml.store.protobuf.serving.ServingServiceProto;
+import dev.caraml.store.protobuf.types.ValueProto;
+import dev.caraml.store.testutils.it.DataGenerator;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class HbaseOnlineRetrieverTest {
+  static Connection hbaseClient;
+  static HBaseAdmin admin;
+  static Configuration hbaseConfiguration = HBaseConfiguration.create();
+  static final String FEAST_PROJECT = "default";
+
+  @Container public static GenericHbase2Container hbase = new GenericHbase2Container();
+
+  @BeforeAll
+  public static void setup() throws IOException {
+    hbaseConfiguration.set("hbase.zookeeper.quorum", hbase.getHost());
+    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", "2181");
+    hbaseClient = ConnectionFactory.createConnection(hbaseConfiguration);
+    admin = (HBaseAdmin) hbaseClient.getAdmin();
+    ingestData();
+  }
+
+  private static void ingestData() throws IOException {
+    String featureTableName = "rides";
+
+    /** Single Entity Ingestion Workflow */
+    Schema schema =
+        SchemaBuilder.record("DriverData")
+            .namespace(featureTableName)
+            .fields()
+            .requiredLong("trip_cost")
+            .requiredDouble("trip_distance")
+            .nullableString("trip_empty", "null")
+            .requiredString("trip_wrong_type")
+            .endRecord();
+    createTable(FEAST_PROJECT, List.of("driver"), List.of(featureTableName));
+    insertSchema(FEAST_PROJECT, List.of("driver"), schema);
+
+    GenericRecord record =
+        new GenericRecordBuilder(schema)
+            .set("trip_cost", 5L)
+            .set("trip_distance", 3.5)
+            .set("trip_empty", null)
+            .set("trip_wrong_type", "test")
+            .build();
+    String entityKey = String.valueOf(DataGenerator.createInt64Value(1).getInt64Val());
+    insertRow(FEAST_PROJECT, List.of("driver"), entityKey, featureTableName, schema, record);
+  }
+
+  private static String getTableName(String project, List<String> entityNames) {
+    return String.format("%s__%s", project, String.join("__", entityNames));
+  }
+
+  private static byte[] serializedSchemaReference(Schema schema) {
+    return Hashing.murmur3_32().hashBytes(schema.toString().getBytes()).asBytes();
+  }
+
+  private static void createTable(
+      String project, List<String> entityNames, List<String> featureTables) {
+    String tableName = getTableName(project, entityNames);
+
+    List<String> columnFamilies =
+        Stream.concat(featureTables.stream(), Stream.of("metadata")).toList();
+    TableDescriptorBuilder tb = TableDescriptorBuilder.newBuilder(TableName.valueOf(tableName));
+    columnFamilies.forEach(cf -> tb.setColumnFamily(ColumnFamilyDescriptorBuilder.of(cf)));
+    try {
+      if (admin.tableExists(TableName.valueOf(tableName))) {
+        return;
+      }
+      admin.createTable(tb.build());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void insertSchema(String project, List<String> entityNames, Schema schema)
+      throws IOException {
+    String tableName = getTableName(project, entityNames);
+    byte[] schemaReference = serializedSchemaReference(schema);
+    byte[] schemaKey = createSchemaKey(schemaReference);
+    Table table = hbaseClient.getTable(TableName.valueOf(tableName));
+    Put put = new Put(schemaKey);
+    put.addColumn("metadata".getBytes(), "avro".getBytes(), schema.toString().getBytes());
+    table.put(put);
+    table.close();
+  }
+
+  private static byte[] createSchemaKey(byte[] schemaReference) throws IOException {
+    String schemaKeyPrefix = "schema#";
+    ByteArrayOutputStream concatOutputStream = new ByteArrayOutputStream();
+    concatOutputStream.write(schemaKeyPrefix.getBytes());
+    concatOutputStream.write(schemaReference);
+    return concatOutputStream.toByteArray();
+  }
+
+  private static byte[] createEntityValue(Schema schema, GenericRecord record) throws IOException {
+    byte[] schemaReference = serializedSchemaReference(schema);
+    // Entity-Feature Row
+    byte[] avroSerializedFeatures = recordToAvro(record, schema);
+
+    ByteArrayOutputStream concatOutputStream = new ByteArrayOutputStream();
+    concatOutputStream.write(schemaReference);
+    concatOutputStream.write("".getBytes());
+    concatOutputStream.write(avroSerializedFeatures);
+    byte[] entityFeatureValue = concatOutputStream.toByteArray();
+
+    return entityFeatureValue;
+  }
+
+  private static byte[] recordToAvro(GenericRecord datum, Schema schema) throws IOException {
+    GenericDatumWriter<Object> writer = new GenericDatumWriter<>(schema);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    Encoder encoder = EncoderFactory.get().binaryEncoder(output, null);
+    writer.write(datum, encoder);
+    encoder.flush();
+
+    return output.toByteArray();
+  }
+
+  private static void insertRow(
+      String project,
+      List<String> entityNames,
+      String entityKey,
+      String featureTableName,
+      Schema schema,
+      GenericRecord record)
+      throws IOException {
+    byte[] entityFeatureValue = createEntityValue(schema, record);
+    String tableName = getTableName(project, entityNames);
+
+    // Update Compound Entity-Feature Row
+    Table table = hbaseClient.getTable(TableName.valueOf(tableName));
+    Put put = new Put(entityKey.getBytes());
+    put.addColumn(featureTableName.getBytes(), "".getBytes(), entityFeatureValue);
+    table.put(put);
+    table.close();
+  }
+
+  @Test
+  public void shouldRetrieveFeaturesSuccessfully() {
+    HBaseOnlineRetriever retriever = new HBaseOnlineRetriever(hbaseClient);
+    List<ServingServiceProto.FeatureReference> featureReferences =
+        Stream.of("trip_cost", "trip_distance")
+            .map(
+                f ->
+                    ServingServiceProto.FeatureReference.newBuilder()
+                        .setFeatureTable("rides")
+                        .setName(f)
+                        .build())
+            .toList();
+    List<String> entityNames = List.of("driver");
+    List<ServingServiceProto.GetOnlineFeaturesRequest.EntityRow> entityRows =
+        List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
+    List<List<Feature>> featuresForRows =
+        retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
+    assertEquals(1, featuresForRows.size());
+    List<Feature> features = featuresForRows.get(0);
+    assertEquals(2, features.size());
+    assertEquals(
+        5L, features.get(0).getFeatureValue(ValueProto.ValueType.Enum.INT64).getInt64Val());
+    assertEquals(featureReferences.get(0), features.get(0).getFeatureReference());
+    assertEquals(
+        3.5, features.get(1).getFeatureValue(ValueProto.ValueType.Enum.DOUBLE).getDoubleVal());
+    assertEquals(featureReferences.get(1), features.get(1).getFeatureReference());
+  }
+
+  @Test
+  public void shouldFilterOutMissingFeatureRefUsingHbase() {
+    HBaseOnlineRetriever retriever = new HBaseOnlineRetriever(hbaseClient);
+    List<ServingServiceProto.FeatureReference> featureReferences =
+        List.of(
+            ServingServiceProto.FeatureReference.newBuilder()
+                .setFeatureTable("rides")
+                .setName("not_exists")
+                .build());
+    List<String> entityNames = List.of("driver");
+    List<ServingServiceProto.GetOnlineFeaturesRequest.EntityRow> entityRows =
+        List.of(DataGenerator.createEntityRow("driver", DataGenerator.createInt64Value(1), 100));
+    List<List<Feature>> features =
+        retriever.getOnlineFeatures(FEAST_PROJECT, entityRows, featureReferences, entityNames);
+    assertEquals(1, features.size());
+    assertEquals(0, features.get(0).size());
+  }
+}

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
@@ -38,9 +38,11 @@ public class HbaseOnlineRetrieverTest {
 
   @BeforeAll
   public static void setup() throws IOException {
-    hbaseConfiguration.set("hbase.zookeeper.quorum", hbase.getHost());
-    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", "2181");
-    hbaseClient = ConnectionFactory.createConnection(hbaseConfiguration);
+//    hbaseConfiguration.set("hbase.zookeeper.quorum", hbase.getHost());
+//    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", hbase.getMappedPort(2181).toString());
+//    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", "2181");
+//    hbaseClient = ConnectionFactory.createConnection(hbaseConfiguration);
+    hbaseClient = ConnectionFactory.createConnection(hbase.hbase2Configuration);
     admin = (HBaseAdmin) hbaseClient.getAdmin();
     ingestData();
   }

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
@@ -38,11 +38,6 @@ public class HbaseOnlineRetrieverTest {
 
   @BeforeAll
   public static void setup() throws IOException {
-    //    hbaseConfiguration.set("hbase.zookeeper.quorum", hbase.getHost());
-    //    hbaseConfiguration.set("hbase.zookeeper.property.clientPort",
-    // hbase.getMappedPort(2181).toString());
-    //    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", "2181");
-    //    hbaseClient = ConnectionFactory.createConnection(hbaseConfiguration);
     hbaseClient = ConnectionFactory.createConnection(hbase.hbase2Configuration);
     admin = (HBaseAdmin) hbaseClient.getAdmin();
     ingestData();

--- a/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
+++ b/caraml-store-serving/src/test/java/dev/caraml/serving/store/bigtable/HbaseOnlineRetrieverTest.java
@@ -38,10 +38,11 @@ public class HbaseOnlineRetrieverTest {
 
   @BeforeAll
   public static void setup() throws IOException {
-//    hbaseConfiguration.set("hbase.zookeeper.quorum", hbase.getHost());
-//    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", hbase.getMappedPort(2181).toString());
-//    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", "2181");
-//    hbaseClient = ConnectionFactory.createConnection(hbaseConfiguration);
+    //    hbaseConfiguration.set("hbase.zookeeper.quorum", hbase.getHost());
+    //    hbaseConfiguration.set("hbase.zookeeper.property.clientPort",
+    // hbase.getMappedPort(2181).toString());
+    //    hbaseConfiguration.set("hbase.zookeeper.property.clientPort", "2181");
+    //    hbaseClient = ConnectionFactory.createConnection(hbaseConfiguration);
     hbaseClient = ConnectionFactory.createConnection(hbase.hbase2Configuration);
     admin = (HBaseAdmin) hbaseClient.getAdmin();
     ingestData();

--- a/caraml-store-spark/docker/Dockerfile
+++ b/caraml-store-spark/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/spark-py:v3.1.3
+FROM --platform=linux/amd64 apache/spark-py:v3.1.3
 
 ARG GCS_CONNECTOR_VERSION=2.2.5
 ARG BQ_CONNECTOR_VERSION=0.27.1

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -33,10 +33,12 @@ object BasePipeline {
         conf
           .set("spark.bigtable.projectId", projectId)
           .set("spark.bigtable.instanceId", instanceId)
-      case HBaseConfig(zookeeperQuorum, zookeeperPort) =>
+      case HBaseConfig(zookeeperQuorum, zookeeperPort, hbaseProperties) =>
         conf
           .set("spark.hbase.zookeeper.quorum", zookeeperQuorum)
           .set("spark.hbase.zookeeper.port", zookeeperPort.toString)
+          .set("spark.hbase.properties.regionSplitPolicyClassName", hbaseProperties.regionSplitPolicy)
+          .set("spark.hbase.properties.compressionAlgorithm", hbaseProperties.compressionAlgorithm)
     }
 
     jobConfig.metrics match {

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -33,6 +33,10 @@ object BasePipeline {
         conf
           .set("spark.bigtable.projectId", projectId)
           .set("spark.bigtable.instanceId", instanceId)
+      case HBaseConfig(zookeeperQuorum, zookeeperPort) =>
+        conf
+          .set("spark.hbase.zookeeper.quorum", zookeeperQuorum)
+          .set("spark.hbase.zookeeper.port", zookeeperPort.toString)
     }
 
     jobConfig.metrics match {

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -37,7 +37,10 @@ object BasePipeline {
         conf
           .set("spark.hbase.zookeeper.quorum", zookeeperQuorum)
           .set("spark.hbase.zookeeper.port", zookeeperPort.toString)
-          .set("spark.hbase.properties.regionSplitPolicyClassName", hbaseProperties.regionSplitPolicy)
+          .set(
+            "spark.hbase.properties.regionSplitPolicyClassName",
+            hbaseProperties.regionSplitPolicy
+          )
           .set("spark.hbase.properties.compressionAlgorithm", hbaseProperties.compressionAlgorithm)
     }
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
@@ -66,11 +66,19 @@ object BatchPipeline extends BasePipeline {
       .map(metrics.incrementRead)
       .filter(rowValidator.allChecks)
 
+    val onlineStore = config.store match {
+      case _: RedisConfig    => "redis"
+      case _: BigTableConfig => "bigtable"
+      case _: HBaseConfig    => "hbase"
+    }
+
     validRows.write
       .format(config.store match {
         case _: RedisConfig    => "dev.caraml.spark.stores.redis"
         case _: BigTableConfig => "dev.caraml.spark.stores.bigtable"
+        case _: HBaseConfig    => "dev.caraml.spark.stores.bigtable"
       })
+      .option("online_store", onlineStore)
       .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
       .option("namespace", featureTable.name)
       .option("project_name", featureTable.project)

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
@@ -87,6 +87,9 @@ object IngestionJob {
     opt[String](name = "bigtable")
       .action((x, c) => c.copy(store = parseJSON(x).camelizeKeys.extract[BigTableConfig]))
 
+    opt[String](name = "hbase")
+      .action((x, c) => c.copy(store = parseJSON(x).extract[HBaseConfig]))
+
     opt[String](name = "statsd")
       .action((x, c) => c.copy(metrics = Some(parseJSON(x).extract[StatsDConfig])))
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -27,7 +27,8 @@ case class RedisWriteProperties(
     ratePerSecondLimit: Int = 50000
 )
 case class BigTableConfig(projectId: String, instanceId: String)    extends StoreConfig
-case class HBaseConfig(zookeeperQuorum: String, zookeeperPort: Int) extends StoreConfig
+case class HBaseConfig(zookeeperQuorum: String, zookeeperPort: Int, hbaseProperties: HBaseProperties = HBaseProperties()) extends StoreConfig
+case class HBaseProperties(regionSplitPolicy: String = "org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy", compressionAlgorithm: String = "ZSTD")
 
 sealed trait MetricConfig
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -26,7 +26,8 @@ case class RedisWriteProperties(
     enableRateLimit: Boolean = false,
     ratePerSecondLimit: Int = 50000
 )
-case class BigTableConfig(projectId: String, instanceId: String) extends StoreConfig
+case class BigTableConfig(projectId: String, instanceId: String)    extends StoreConfig
+case class HBaseConfig(zookeeperQuorum: String, zookeeperPort: Int) extends StoreConfig
 
 sealed trait MetricConfig
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -26,9 +26,17 @@ case class RedisWriteProperties(
     enableRateLimit: Boolean = false,
     ratePerSecondLimit: Int = 50000
 )
-case class BigTableConfig(projectId: String, instanceId: String)    extends StoreConfig
-case class HBaseConfig(zookeeperQuorum: String, zookeeperPort: Int, hbaseProperties: HBaseProperties = HBaseProperties()) extends StoreConfig
-case class HBaseProperties(regionSplitPolicy: String = "org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy", compressionAlgorithm: String = "ZSTD")
+case class BigTableConfig(projectId: String, instanceId: String) extends StoreConfig
+case class HBaseConfig(
+    zookeeperQuorum: String,
+    zookeeperPort: Int,
+    hbaseProperties: HBaseProperties = HBaseProperties()
+) extends StoreConfig
+case class HBaseProperties(
+    regionSplitPolicy: String =
+      "org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy",
+    compressionAlgorithm: String = "ZSTD"
+)
 
 sealed trait MetricConfig
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
@@ -77,6 +77,12 @@ object StreamingPipeline extends BasePipeline with Serializable {
       case _ => Array()
     }
 
+    val onlineStore = config.store match {
+      case _: RedisConfig    => "redis"
+      case _: BigTableConfig => "bigtable"
+      case _: HBaseConfig    => "hbase"
+    }
+
     val parsed = input
       .withColumn("features", featureStruct)
       .select(metadata :+ col("features.*"): _*)
@@ -108,7 +114,9 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .format(config.store match {
             case _: RedisConfig    => "dev.caraml.spark.stores.redis"
             case _: BigTableConfig => "dev.caraml.spark.stores.bigtable"
+            case _: HBaseConfig    => "dev.caraml.spark.stores.bigtable"
           })
+          .option("online_store", onlineStore)
           .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
           .option("namespace", featureTable.name)
           .option("project_name", featureTable.project)

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/BigTableSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/BigTableSinkRelation.scala
@@ -62,7 +62,6 @@ class BigTableSinkRelation(
       featuresCFBuilder.setMaxVersions(1)
       val featuresCF = featuresCFBuilder.build()
 
-      // TODO: Set compression type for column family
       val tdb = TableDescriptorBuilder.newBuilder(table)
 
       if (!table.getColumnFamilyNames.contains(config.namespace.getBytes)) {

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/BigTableSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/BigTableSinkRelation.scala
@@ -4,7 +4,13 @@ import com.google.cloud.bigtable.hbase.BigtableConfiguration
 import dev.caraml.spark.serialization.Serializer
 import dev.caraml.spark.utils.StringUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.hbase.client.Put
+import org.apache.hadoop.hbase.client.{
+  Admin,
+  ColumnFamilyDescriptorBuilder,
+  Connection,
+  Put,
+  TableDescriptorBuilder
+}
 import org.apache.hadoop.hbase.mapred.TableOutputFormat
 import org.apache.hadoop.hbase.{HColumnDescriptor, HTableDescriptor, TableName}
 import org.apache.hadoop.mapred.JobConf
@@ -30,42 +36,49 @@ class BigTableSinkRelation(
 
   override def schema: StructType = ???
 
+  def getConnection(hadoopConfig: Configuration): Connection = {
+    BigtableConfiguration.connect(hadoopConfig)
+  }
+
   def createTable(): Unit = {
-    val btConn = BigtableConfiguration.connect(hadoopConfig)
+    val btConn = getConnection(hadoopConfig)
     try {
       val admin = btConn.getAdmin
 
       val table = if (!admin.isTableAvailable(TableName.valueOf(tableName))) {
-        val t          = new HTableDescriptor(TableName.valueOf(tableName))
-        val metadataCF = new HColumnDescriptor(metadataColumnFamily)
-        t.addFamily(metadataCF)
-        t
+        val tableBuilder = TableDescriptorBuilder.newBuilder(TableName.valueOf(tableName))
+        val cf           = ColumnFamilyDescriptorBuilder.of(metadataColumnFamily)
+        tableBuilder.setColumnFamily(cf)
+        val table = tableBuilder.build()
+        table
       } else {
-        admin.getTableDescriptor(TableName.valueOf(tableName))
+        val t = btConn.getTable(TableName.valueOf(tableName))
+        t.getDescriptor()
       }
-
-      val featuresCF = new HColumnDescriptor(config.namespace)
+      val featuresCFBuilder = ColumnFamilyDescriptorBuilder.newBuilder(config.namespace.getBytes)
       if (config.maxAge > 0) {
-        featuresCF.setTimeToLive(config.maxAge.toInt)
+        featuresCFBuilder.setTimeToLive(config.maxAge.toInt)
       }
+      featuresCFBuilder.setMaxVersions(1)
+      val featuresCF = featuresCFBuilder.build()
 
-      featuresCF.setMaxVersions(1)
-
+      // TODO: Set compression type for column family
+      val tdb = TableDescriptorBuilder.newBuilder(table)
       if (!table.getColumnFamilyNames.contains(config.namespace.getBytes)) {
-        table.addFamily(featuresCF)
-
+        tdb.setColumnFamily(featuresCF)
+        val t = tdb.build()
         if (!admin.isTableAvailable(table.getTableName)) {
-          admin.createTable(table)
+          admin.createTable(t)
         } else {
-          admin.modifyTable(table)
+          admin.modifyTable(t)
         }
       } else if (
         config.maxAge > 0 && table
           .getColumnFamily(config.namespace.getBytes)
           .getTimeToLive != featuresCF.getTimeToLive
       ) {
-        table.modifyFamily(featuresCF)
-        admin.modifyTable(table)
+        tdb.modifyColumnFamily(featuresCF)
+        admin.modifyTable(tdb.build())
       }
     } finally {
       btConn.close()
@@ -115,7 +128,7 @@ class BigTableSinkRelation(
     val qualifier = "avro".getBytes
     put.addColumn(metadataColumnFamily.getBytes, qualifier, schema.asInstanceOf[String].getBytes)
 
-    val btConn = BigtableConfiguration.connect(hadoopConfig)
+    val btConn = getConnection(hadoopConfig)
     try {
       val table = btConn.getTable(TableName.valueOf(tableName))
       table.checkAndPut(

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/BigTableSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/BigTableSinkRelation.scala
@@ -64,6 +64,7 @@ class BigTableSinkRelation(
 
       // TODO: Set compression type for column family
       val tdb = TableDescriptorBuilder.newBuilder(table)
+
       if (!table.getColumnFamilyNames.contains(config.namespace.getBytes)) {
         tdb.setColumnFamily(featuresCF)
         val t = tdb.build()
@@ -143,19 +144,19 @@ class BigTableSinkRelation(
     }
   }
 
-  private def tableName: String = {
+  protected def tableName: String = {
     val entities = config.entityColumns.sorted.mkString("__")
     StringUtils.trimAndHash(s"${config.projectName}__${entities}", maxTableNameLength)
   }
 
-  private def joinEntityKey: UserDefinedFunction = udf { r: Row =>
+  protected def joinEntityKey: UserDefinedFunction = udf { r: Row =>
     ((0 until r.size)).map(r.getString).mkString("#").getBytes
   }
 
-  private val metadataColumnFamily = "metadata"
-  private val schemaKeyPrefix      = "schema#"
-  private val emptyQualifier       = ""
-  private val maxTableNameLength   = 50
+  protected val metadataColumnFamily = "metadata"
+  protected val schemaKeyPrefix      = "schema#"
+  protected val emptyQualifier       = ""
+  protected val maxTableNameLength   = 50
 
   private def isSystemColumn(name: String) =
     (config.entityColumns ++ Seq(config.timestampColumn)).contains(name)

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
@@ -2,7 +2,9 @@ package dev.caraml.spark.stores.bigtable
 
 import dev.caraml.spark.serialization.Serializer
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory}
+import org.apache.hadoop.hbase.TableName
+import org.apache.hadoop.hbase.client.{ColumnFamilyDescriptorBuilder, Connection, ConnectionFactory, TableDescriptorBuilder}
+import org.apache.hadoop.hbase.io.compress.Compression
 import org.apache.spark.sql.SQLContext
 
 class HbaseSinkRelation(
@@ -13,5 +15,52 @@ class HbaseSinkRelation(
 ) extends BigTableSinkRelation(sqlContext, serializer, config, hadoopConfig) {
   override def getConnection(hadoopConfig: Configuration): Connection = {
     ConnectionFactory.createConnection(hadoopConfig)
+  }
+  override def createTable(): Unit = {
+    val hbaseConn = getConnection(hadoopConfig)
+    try {
+      val admin = hbaseConn.getAdmin
+
+      val table = if (!admin.isTableAvailable(TableName.valueOf(tableName))) {
+        val tableBuilder = TableDescriptorBuilder.newBuilder(TableName.valueOf(tableName))
+        val cf           = ColumnFamilyDescriptorBuilder.of(metadataColumnFamily)
+        tableBuilder.setColumnFamily(cf)
+        val table = tableBuilder.build()
+        table
+      } else {
+        val t = hbaseConn.getTable(TableName.valueOf(tableName))
+        t.getDescriptor()
+      }
+      val featuresCFBuilder = ColumnFamilyDescriptorBuilder.newBuilder(config.namespace.getBytes)
+      if (config.maxAge > 0) {
+        featuresCFBuilder.setTimeToLive(config.maxAge.toInt)
+      }
+      featuresCFBuilder.setMaxVersions(1)
+      featuresCFBuilder.setCompressionType(Compression.Algorithm.ZSTD)
+      val featuresCF = featuresCFBuilder.build()
+
+      val tdb = TableDescriptorBuilder.newBuilder(table)
+      // TODO: make this configurable
+      tdb.setRegionSplitPolicyClassName("org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy")
+
+      if (!table.getColumnFamilyNames.contains(config.namespace.getBytes)) {
+        tdb.setColumnFamily(featuresCF)
+        val t = tdb.build()
+        if (!admin.isTableAvailable(table.getTableName)) {
+          admin.createTable(t)
+        } else {
+          admin.modifyTable(t)
+        }
+      } else if (
+        config.maxAge > 0 && table
+          .getColumnFamily(config.namespace.getBytes)
+          .getTimeToLive != featuresCF.getTimeToLive
+      ) {
+        tdb.modifyColumnFamily(featuresCF)
+        admin.modifyTable(tdb.build())
+      }
+    } finally {
+      hbaseConn.close()
+    }
   }
 }

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
@@ -1,0 +1,17 @@
+package dev.caraml.spark.stores.bigtable
+
+import dev.caraml.spark.serialization.Serializer
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory}
+import org.apache.spark.sql.SQLContext
+
+class HbaseSinkRelation(
+    sqlContext: SQLContext,
+    serializer: Serializer,
+    config: SparkBigtableConfig,
+    hadoopConfig: Configuration
+) extends BigTableSinkRelation(sqlContext, serializer, config, hadoopConfig) {
+  override def getConnection(hadoopConfig: Configuration): Connection = {
+    ConnectionFactory.createConnection(hadoopConfig)
+  }
+}

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
@@ -3,7 +3,12 @@ package dev.caraml.spark.stores.bigtable
 import dev.caraml.spark.serialization.Serializer
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hbase.TableName
-import org.apache.hadoop.hbase.client.{ColumnFamilyDescriptorBuilder, Connection, ConnectionFactory, TableDescriptorBuilder}
+import org.apache.hadoop.hbase.client.{
+  ColumnFamilyDescriptorBuilder,
+  Connection,
+  ConnectionFactory,
+  TableDescriptorBuilder
+}
 import org.apache.hadoop.hbase.io.compress.Compression
 import org.apache.spark.sql.SQLContext
 
@@ -41,7 +46,9 @@ class HbaseSinkRelation(
 
       val tdb = TableDescriptorBuilder.newBuilder(table)
       // TODO: make this configurable
-      tdb.setRegionSplitPolicyClassName("org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy")
+      tdb.setRegionSplitPolicyClassName(
+        "org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy"
+      )
 
       if (!table.getColumnFamilyNames.contains(config.namespace.getBytes)) {
         tdb.setColumnFamily(featuresCF)

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/stores/bigtable/HbaseSinkRelation.scala
@@ -42,11 +42,11 @@ class HbaseSinkRelation(
       }
       featuresCFBuilder.setMaxVersions(1)
       sqlContext.getConf("spark.hbase.properties.compressionAlgorithm") match {
-        case "ZSTD" => featuresCFBuilder.setCompressionType(Compression.Algorithm.ZSTD)
-        case "GZ" => featuresCFBuilder.setCompressionType(Compression.Algorithm.GZ)
-        case "LZ4" => featuresCFBuilder.setCompressionType(Compression.Algorithm.LZ4)
+        case "ZSTD"   => featuresCFBuilder.setCompressionType(Compression.Algorithm.ZSTD)
+        case "GZ"     => featuresCFBuilder.setCompressionType(Compression.Algorithm.GZ)
+        case "LZ4"    => featuresCFBuilder.setCompressionType(Compression.Algorithm.LZ4)
         case "SNAPPY" => featuresCFBuilder.setCompressionType(Compression.Algorithm.SNAPPY)
-        case _ => featuresCFBuilder.setCompressionType(Compression.Algorithm.NONE)
+        case _        => featuresCFBuilder.setCompressionType(Compression.Algorithm.NONE)
       }
       val featuresCF = featuresCFBuilder.build()
 


### PR DESCRIPTION
# Summary
This PR adds support to use hbase as the online store.
- Read data from BigTable and Hbase in caraml-serving by using HBase SDK by set configuration `caraml.store.bigtable.isUsingHBaseSDK` become `true`. If the value is `false`, then it will read data by using BigTable SDK.
- Modifies spark job to ingest the data into HBase for stream and batch ingestion, but reuses most of the existing logic to pull data from BigTable.
- Add additional unit tests to read data from bigtable using HBase sdk, and to read data from hbase directly
- Refactor bigtable online store to share BaseSchemaRegistry