### PR TITLE
feat: Set subscribe pattern to wildcard prefix

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
@@ -55,7 +55,10 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .format("kafka")
           .option("kafka.bootstrap.servers", source.bootstrapServers)
           .option("subscribePattern", s"^(.*\\.|)${source.topic}")
-          .option("kafka.metadata.max.age.ms", "5000") // set max age to 5s to refresh for topics every 5s
+          .option(
+            "kafka.metadata.max.age.ms",
+            "5000"
+          ) // set max age to 5s to refresh for topics every 5s
           .load()
       case source: MemoryStreamingSource =>
         source.read

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
@@ -54,7 +54,8 @@ object StreamingPipeline extends BasePipeline with Serializable {
         sparkSession.readStream
           .format("kafka")
           .option("kafka.bootstrap.servers", source.bootstrapServers)
-          .option("subscribe", source.topic)
+//          .option("subscribe", source.topic)
+          .option("subscribePattern", s".*\\.${source.topic}")
           .load()
       case source: MemoryStreamingSource =>
         source.read

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala
@@ -54,8 +54,8 @@ object StreamingPipeline extends BasePipeline with Serializable {
         sparkSession.readStream
           .format("kafka")
           .option("kafka.bootstrap.servers", source.bootstrapServers)
-//          .option("subscribe", source.topic)
-          .option("subscribePattern", s".*\\.${source.topic}")
+          .option("subscribePattern", s"^(.*\\.|)${source.topic}")
+          .option("kafka.metadata.max.age.ms", "5000") // set max age to 5s to refresh for topics every 5s
           .load()
       case source: MemoryStreamingSource =>
         source.read

--- a/caraml-store-spark/src/test/scala/dev/caraml/spark/StreamingPipelineSpec.scala
+++ b/caraml-store-spark/src/test/scala/dev/caraml/spark/StreamingPipelineSpec.scala
@@ -1,10 +1,19 @@
 package dev.caraml.spark
 
-import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer, KafkaContainer, MultipleContainers}
+import com.dimafeng.testcontainers.{
+  ForAllTestContainer,
+  GenericContainer,
+  KafkaContainer,
+  MultipleContainers
+}
 import com.example.protos.{AllTypesMessage, InnerMessage, TestMessage, VehicleType}
 import com.google.protobuf.{AbstractMessage, ByteString, Timestamp}
 import dev.caraml.spark.helpers.DataHelper.{generateDistinctRows, generateTempPath}
-import dev.caraml.spark.helpers.RedisStorageHelper.{beStoredRow, encodeFeatureKey, murmurHashHexString}
+import dev.caraml.spark.helpers.RedisStorageHelper.{
+  beStoredRow,
+  encodeFeatureKey,
+  murmurHashHexString
+}
 import dev.caraml.spark.helpers.TestRow
 import dev.caraml.store.protobuf.types.ValueProto.ValueType
 import org.apache.commons.codec.digest.DigestUtils

--- a/caraml-store-spark/src/test/scala/dev/caraml/spark/StreamingPipelineSpec.scala
+++ b/caraml-store-spark/src/test/scala/dev/caraml/spark/StreamingPipelineSpec.scala
@@ -1,23 +1,16 @@
 package dev.caraml.spark
 
-import com.dimafeng.testcontainers.{
-  ForAllTestContainer,
-  GenericContainer,
-  KafkaContainer,
-  MultipleContainers
-}
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer, KafkaContainer, MultipleContainers}
 import com.example.protos.{AllTypesMessage, InnerMessage, TestMessage, VehicleType}
 import com.google.protobuf.{AbstractMessage, ByteString, Timestamp}
 import dev.caraml.spark.helpers.DataHelper.{generateDistinctRows, generateTempPath}
-import dev.caraml.spark.helpers.RedisStorageHelper.{
-  beStoredRow,
-  encodeFeatureKey,
-  murmurHashHexString
-}
+import dev.caraml.spark.helpers.RedisStorageHelper.{beStoredRow, encodeFeatureKey, murmurHashHexString}
 import dev.caraml.spark.helpers.TestRow
 import dev.caraml.store.protobuf.types.ValueProto.ValueType
 import org.apache.commons.codec.digest.DigestUtils
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer._
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.avro.to_avro
@@ -129,8 +122,8 @@ class StreamingPipelineSpec extends SparkSpec with ForAllTestContainer {
     val rows = generateDistinctRows(rowGenerator, 1000, groupByEntity)
     rows.foreach(sendToKafka(kafkaSource.topic, _))
 
+    Thread.sleep(10000); // sleep for 10s to allow topic discovery
     query.processAllAvailable()
-
     rows.foreach { r =>
       val encodedEntityKey = encodeEntityKey(r, config.featureTable)
       val storedValues     = jedis.hgetAll(encodedEntityKey).asScala.toMap
@@ -145,8 +138,36 @@ class StreamingPipelineSpec extends SparkSpec with ForAllTestContainer {
       val keyTTL = jedis.ttl(encodedEntityKey).toInt
       keyTTL shouldEqual -1
     }
+
   }
 
+  "Streaming pipeline" should "store valid proto messages from kafka to redis when reading from topics with prefix" in new Scope {
+    val configWithKafka = config.copy(source = kafkaSource)
+    val query           = StreamingPipeline.createPipeline(sparkSession, configWithKafka).get
+    query.processAllAvailable() // to init kafka consumer
+
+    val rowsV2 = generateDistinctRows(rowGenerator, 10, groupByEntity)
+    rowsV2.foreach(sendToKafka(s"GCP.${kafkaSource.topic}", _))
+
+    Thread.sleep(10000); // sleep for 10s to allow topic discovery
+    query.processAllAvailable()
+    rowsV2.foreach { r =>
+      val encodedEntityKey = encodeEntityKey(r, config.featureTable)
+      val storedValues     = jedis.hgetAll(encodedEntityKey).asScala.toMap
+      print(s"r2: ${r}, storedValues: ${storedValues}")
+      storedValues should beStoredRow(
+        Map(
+          featureKeyEncoder("unique_drivers") -> r.getUniqueDrivers,
+          murmurHashHexString("_ts:driver-fs") -> new java.sql.Timestamp(
+            r.getEventTimestamp.getSeconds * 1000
+          )
+        )
+      )
+      val keyTTL = jedis.ttl(encodedEntityKey).toInt
+      keyTTL shouldEqual -1
+    }
+
+  }
   "Streaming pipeline" should "store messages from kafka to redis with expiry time equal to entity max age" in new Scope {
     val maxAge       = 86400L
     val entityMaxAge = 1728000L
@@ -380,7 +401,7 @@ class StreamingPipelineSpec extends SparkSpec with ForAllTestContainer {
       .option("kafka.bootstrap.servers", kafkaContainer.bootstrapServers)
       .option("topic", "avro")
       .save()
-
+    Thread.sleep(10000)
     query.processAllAvailable()
 
     val redisKey = DigestUtils.md5Hex(s"default#customer:aaa").getBytes()


### PR DESCRIPTION
### Summary
- Enable streaming ingestion jobs to read topics using `subscribePattern` instead of `subscribe`
- This is only supported in the spark job, topics in the feature table data source should specify exact topic