### PR TITLE
update python version of gitlab runner for sdk release

### DIFF
--- a/.github/workflows/sdk_release.yaml
+++ b/.github/workflows/sdk_release.yaml
@@ -3,13 +3,12 @@ name: CaraML Store SDK Release
 on:
   # Automatically run CI on SDK release
   # (only if there are changes to relevant paths)
-  pull_request:
-#  push:
-#    tags:
-#      - "caraml-store-sdk/python/v[0-9]+.[0-9]+.[0-9]+*"
-#    paths:
-#      - ".github/workflows/sdk_release.yaml"
-#      - "caraml-store-sdk/python/**"
+  push:
+    tags:
+      - "caraml-store-sdk/python/v[0-9]+.[0-9]+.[0-9]+*"
+    paths:
+      - ".github/workflows/sdk_release.yaml"
+      - "caraml-store-sdk/python/**"
 
 jobs:
   publish:
@@ -31,9 +30,9 @@ jobs:
       - name: Package
         run: make package-python-sdk
 
-#      - name: Publish
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          user: __token__
-#          password: ${{ secrets.PYPI_API_TOKEN }}
-#          packages_dir: caraml-store-sdk/python/dist
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: caraml-store-sdk/python/dist

--- a/.github/workflows/sdk_release.yaml
+++ b/.github/workflows/sdk_release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.7.1
           cache: 'pip'
           cache-dependency-path: '**/requirements-build.txt'
 

--- a/.github/workflows/sdk_release.yaml
+++ b/.github/workflows/sdk_release.yaml
@@ -3,12 +3,13 @@ name: CaraML Store SDK Release
 on:
   # Automatically run CI on SDK release
   # (only if there are changes to relevant paths)
-  push:
-    tags:
-      - "caraml-store-sdk/python/v[0-9]+.[0-9]+.[0-9]+*"
-    paths:
-      - ".github/workflows/sdk_release.yaml"
-      - "caraml-store-sdk/python/**"
+  pull_request:
+#  push:
+#    tags:
+#      - "caraml-store-sdk/python/v[0-9]+.[0-9]+.[0-9]+*"
+#    paths:
+#      - ".github/workflows/sdk_release.yaml"
+#      - "caraml-store-sdk/python/**"
 
 jobs:
   publish:
@@ -30,9 +31,9 @@ jobs:
       - name: Package
         run: make package-python-sdk
 
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: caraml-store-sdk/python/dist
+#      - name: Publish
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_API_TOKEN }}
+#          packages_dir: caraml-store-sdk/python/dist

--- a/.github/workflows/sdk_release.yaml
+++ b/.github/workflows/sdk_release.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7.1
+          python-version: 3.7
           cache: 'pip'
           cache-dependency-path: '**/requirements-build.txt'
 


### PR DESCRIPTION
Using ubuntu-latest as base image to generate sdk release/push to pypi doesn't work with python3.7 version 
The pipeline - https://github.com/caraml-dev/caraml-store/actions/runs/13362528259
The discussion - https://github.com/actions/setup-python/issues/962
Tested and worked - https://github.com/caraml-dev/caraml-store/actions/runs/13363489867/job/37316971422
To fix, using ubuntu-22.04 helps resolve the issue