### PR TITLE
modify maxcompute reader jdbc query to use partition

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -19,10 +19,9 @@ object MaxComputeReader {
       "jdbc:odps:https://service.ap-southeast-5.maxcompute.aliyun.com/api/?project=%s&interactiveMode=True&enableLimit=False" format source.project
 
     val sqlQuery =
-      "(select * from `%s.%s`  where to_millis(%s) > %d and to_millis(%s) < %d)" format (
-        source.dataset, source.table, source.eventTimestampColumn, start.getMillis, source.eventTimestampColumn, end.getMillis
+      "(select * from `%s.%s` where %s > cast(to_date('%s','yyyy-mm-ddThh:mi:ss.ff3Z') as timestamp) and %s < cast(to_date('%s','yyyy-mm-ddThh:mi:ss.ff3Z') as timestamp))" format (
+        source.dataset, source.table, source.eventTimestampColumn, start, source.eventTimestampColumn, end
       )
-    println("query to maxcompute is", sqlQuery)
 
     val customDialect = new CustomDialect()
     JdbcDialects.registerDialect(customDialect)
@@ -36,8 +35,6 @@ object MaxComputeReader {
       .option("user", maxComputeAccessID)
       .option("password", maxComputeAccessKey)
       .load()
-
-    println("total rows fetched from maxcompute", data.toDF().count())
 
     data.toDF()
   }


### PR DESCRIPTION
The MaxCompute reader retrieves the event_time_stamp column as epoch time by converting it using to_millis() and then querying the records. However, this approach bypasses the automatically created partitions, causing the queries to fail.

Using Spark to filter records by timestamp isn't a viable option because it does not utilize the auto-partitioning. Spark loads the entire table into memory before applying filters, which bypasses the partitioning mechanism.

This PR - reads the records by casting the datetime to a timestamp using MaxCompute's CAST() function. This allows the filtering of records while also leveraging the auto-partitioning feature.