### PR TITLE
feat: Modify maxcompute configs to be parsable from command line

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
@@ -49,6 +49,7 @@ object BatchPipeline extends BasePipeline {
         MaxComputeReader.createBatchSource(
           sparkSession,
           source,
+          config.maxCompute,
           config.startTime,
           config.endTime
         )
@@ -62,17 +63,35 @@ object BatchPipeline extends BasePipeline {
         input.schema
       )
 
-    val projected = if (config.deadLetterPath.nonEmpty) {
-      input.select(projection: _*).cache()
+    val projected = if (config.debug || config.deadLetterPath.nonEmpty) {
+      input.select(projection: _*).persist()
     } else {
       input.select(projection: _*)
     }
 
+    if (config.debug) {
+      val projectedCount = projected.count()
+      println(s"[DEBUG] After projection - row count: $projectedCount")
+    }
+
     implicit val rowEncoder: Encoder[Row] = RowEncoder(projected.schema)
 
-    val validRows = projected
-      .map(metrics.incrementRead)
-      .filter(rowValidator.allChecks)
+    val validRows = if (config.debug) {
+      projected
+        .map(metrics.incrementRead)
+        .filter(rowValidator.allChecks)
+        .persist()
+    } else {
+      projected
+        .map(metrics.incrementRead)
+        .filter(rowValidator.allChecks)
+    }
+
+    if (config.debug) {
+      val validRowCount = validRows.count()
+      println(s"[DEBUG] Valid rows count: $validRowCount")
+    }
+
 
     val onlineStore = config.store match {
       case _: RedisConfig    => "redis"
@@ -95,14 +114,27 @@ object BatchPipeline extends BasePipeline {
       .option("entity_max_age", config.entityMaxAge.getOrElse(0L))
       .save()
 
-    config.deadLetterPath foreach { path =>
-      projected
-        .filter(!rowValidator.allChecks)
+    if (config.debug && config.deadLetterPath.isDefined) {
+      val invalidRows = projected.filter(!rowValidator.allChecks)
+      val invalidRowCount = invalidRows.count()
+      println(s"[DEBUG] Invalid rows count: $invalidRowCount")
+      
+      invalidRows
         .map(metrics.incrementDeadLetters)
         .write
         .format("parquet")
         .mode(SaveMode.Append)
-        .save(StringUtils.stripEnd(path, "/") + "/" + SparkEnv.get.conf.getAppId)
+        .save(StringUtils.stripEnd(config.deadLetterPath.get, "/") + "/" + SparkEnv.get.conf.getAppId)
+    } else {
+      config.deadLetterPath foreach { path =>
+        projected
+          .filter(!rowValidator.allChecks)
+          .map(metrics.incrementDeadLetters)
+          .write
+          .format("parquet")
+          .mode(SaveMode.Append)
+          .save(StringUtils.stripEnd(path, "/") + "/" + SparkEnv.get.conf.getAppId)
+      }
     }
 
     None

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
@@ -64,7 +64,7 @@ object BatchPipeline extends BasePipeline {
       )
 
     val projected = if (config.debug || config.deadLetterPath.nonEmpty) {
-      input.select(projection: _*).persist()
+      input.select(projection: _*).cache()
     } else {
       input.select(projection: _*)
     }

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
@@ -32,8 +32,7 @@ object IngestionJob {
         val json = parseJSON(x)
         JsonUtils
           .mapFieldWithParent(json) {
-            case (parent: String, (key: String, v: JValue))
-                if !parent.equals("fieldMapping") =>
+            case (parent: String, (key: String, v: JValue)) if !parent.equals("fieldMapping") =>
               JsonUtils.camelize(key) -> v
             case (_, x) => x
           }
@@ -58,8 +57,7 @@ object IngestionJob {
 
         c.copy(
           featureTable = ft,
-          streamingTriggeringSecs =
-            ft.labels.getOrElse("_streaming_trigger_secs", "0").toInt,
+          streamingTriggeringSecs = ft.labels.getOrElse("_streaming_trigger_secs", "0").toInt,
           validationConfig = ft.labels
             .get("_validation")
             .map(parseJSON(_).camelizeKeys.extract[ValidationConfig]),
@@ -99,17 +97,13 @@ object IngestionJob {
       .action((x, c) => c.copy(store = parseJSON(x).extract[RedisConfig]))
 
     opt[String](name = "bigtable")
-      .action((x, c) =>
-        c.copy(store = parseJSON(x).camelizeKeys.extract[BigTableConfig])
-      )
+      .action((x, c) => c.copy(store = parseJSON(x).camelizeKeys.extract[BigTableConfig]))
 
     opt[String](name = "hbase")
       .action((x, c) => c.copy(store = parseJSON(x).extract[HBaseConfig]))
 
     opt[String](name = "statsd")
-      .action((x, c) =>
-        c.copy(metrics = Some(parseJSON(x).extract[StatsDConfig]))
-      )
+      .action((x, c) => c.copy(metrics = Some(parseJSON(x).extract[StatsDConfig])))
 
     opt[String](name = "deadletter-path")
       .action((x, c) => c.copy(deadLetterPath = Some(x)))
@@ -137,7 +131,7 @@ object IngestionJob {
       .text("Enable debug mode with additional metrics and data persistence")
 
     opt[String](name = "maxcompute")
-      .action((x, c) => 
+      .action((x, c) =>
         c.copy(maxCompute = Some(parseJSON(x).camelizeKeys.extract[MaxComputeConfig]))
       )
       .text("JSON-encoded MaxCompute configuration")

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
@@ -116,6 +116,16 @@ object IngestionJob {
     opt[String](name = "bq")
       .action((x, c) => c.copy(bq = Some(parseJSON(x).extract[BQConfig])))
 
+    opt[Unit]("debug")
+      .action((_, c) => c.copy(debug = true))
+      .text("Enable debug mode with additional metrics and data persistence")
+
+    opt[String](name = "maxcompute")
+      .action((x, c) => 
+        c.copy(maxCompute = Some(parseJSON(x).camelizeKeys.extract[MaxComputeConfig]))
+      )
+      .text("JSON-encoded MaxCompute configuration")
+
   }
 
   def main(args: Array[String]): Unit = {

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -132,10 +132,10 @@ case class ExpectationSpec(
 )
 
 case class MaxComputeConfig(
-  endpoint: String = "",
-  interactiveMode: Boolean = true,
-  enableLimit: Boolean = false,
-  autoSelectLimit: String = "1000000000"
+    endpoint: String = "",
+    interactiveMode: Boolean = true,
+    enableLimit: Boolean = false,
+    autoSelectLimit: String = "1000000000"
 )
 
 case class IngestionJobConfig(

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -131,6 +131,13 @@ case class ExpectationSpec(
     expectations: List[Expectation]
 )
 
+case class MaxComputeConfig(
+  endpoint: String = "",
+  interactiveMode: Boolean = true,
+  enableLimit: Boolean = false,
+  autoSelectLimit: String = "1000000000"
+)
+
 case class IngestionJobConfig(
     mode: Modes = Modes.Offline,
     featureTable: FeatureTable = null,
@@ -148,5 +155,7 @@ case class IngestionJobConfig(
     expectationSpec: Option[ExpectationSpec] = None,
     doNotIngestInvalidRows: Boolean = false,
     checkpointPath: Option[String] = None,
-    bq: Option[BQConfig] = None
+    bq: Option[BQConfig] = None,
+    debug: Boolean = false,
+    maxCompute: Option[MaxComputeConfig] = None
 )

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -14,11 +14,11 @@ object MaxComputeReader {
       start: DateTime,
       end: DateTime
   ): DataFrame = {
-    val maxComputeAccessID = sys.env("CARAML_SPARK_MAXCOMPUTE_ACCESS_ID")
+    val maxComputeAccessID  = sys.env("CARAML_SPARK_MAXCOMPUTE_ACCESS_ID")
     val maxComputeAccessKey = sys.env("CARAML_SPARK_MAXCOMPUTE_ACCESS_KEY")
-    
+
     val config = maxComputeConfig.getOrElse(MaxComputeConfig())
-    
+
     val maxComputeJDBCConnectionURL =
       "jdbc:odps:%s/?project=%s&interactiveMode=%s&enableLimit=%s&autoSelectLimit=%s"
         .format(


### PR DESCRIPTION
### Summary
* This PR moves maxcompute jdbc configurations into it's own case class and parses them in as command line arguments
* Adds default autoSelectLimit of 1,000,000,000 rows, see maxcompute [docs](https://www.alibabacloud.com/help/en/maxcompute/user-guide/maxcompute-query-acceleration) for more info
* Add debug option to print rows read from source and pushed to sink
* Format code