### PR TITLE
feat: stage entities to maxcompute utility, modify accepted format for mc datasource

### DIFF
--- a/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/adapter/DataSourceConverter.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/sparkjob/adapter/DataSourceConverter.java
@@ -133,13 +133,13 @@ class DataSourceConverter {
       case MAXCOMPUTE_OPTIONS -> {
         DataSourceProto.DataSource.MaxComputeOptions options =
             sourceProtobuf.getMaxcomputeOptions();
-        Pattern pattern = Pattern.compile("(?<project>[^:]+):(?<dataset>[^.]+).(?<table>.+)");
+        Pattern pattern = Pattern.compile("(?<project>[^.:]+)[.:](?<dataset>[^.]+).(?<table>.+)");
         Matcher matcher = pattern.matcher(options.getTableRef());
         matcher.find();
         if (!matcher.matches()) {
           throw new IllegalArgumentException(
               String.format(
-                  "Table ref '%s' is not in the form of <project>:<dataset>.<table>",
+                  "Table ref '%s' is not in the form of <project>:<dataset>.<table> or <project>.<dataset>.<table>",
                   options.getTableRef()));
         }
         String project = matcher.group("project");

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
@@ -28,28 +28,30 @@ class DataSourceConverterTest {
 
   @Test
   void getArgumentsForMaxcomputeSource() throws JsonProcessingException {
-    DataSource source = 
-      DataSource.newBuilder()
-      .setEventTimestampColumn("event_timestamp")
-      .setType(DataSource.SourceType.BATCH_MAXCOMPUTE)
-      .setMaxcomputeOptions(
-        DataSource.MaxComputeOptions.newBuilder()
-          .setTableRef("project.schema.table")
-          .build())
-      .build();
+    DataSource source =
+        DataSource.newBuilder()
+            .setEventTimestampColumn("event_timestamp")
+            .setType(DataSource.SourceType.BATCH_MAXCOMPUTE)
+            .setMaxcomputeOptions(
+                DataSource.MaxComputeOptions.newBuilder()
+                    .setTableRef("project.schema.table")
+                    .build())
+            .build();
     DataSourceConverter dataSourceConverter = new DataSourceConverter();
-    String expected =  "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+    String expected =
+        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
     assertEquals(expected, dataSourceConverter.convert(source));
-    DataSource source2 = 
-      DataSource.newBuilder()
-      .setEventTimestampColumn("event_timestamp")
-      .setType(DataSource.SourceType.BATCH_MAXCOMPUTE)
-      .setMaxcomputeOptions(
-        DataSource.MaxComputeOptions.newBuilder()
-          .setTableRef("project:schema.table")
-          .build())
-      .build();
-    String expected2 =  "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+    DataSource source2 =
+        DataSource.newBuilder()
+            .setEventTimestampColumn("event_timestamp")
+            .setType(DataSource.SourceType.BATCH_MAXCOMPUTE)
+            .setMaxcomputeOptions(
+                DataSource.MaxComputeOptions.newBuilder()
+                    .setTableRef("project:schema.table")
+                    .build())
+            .build();
+    String expected2 =
+        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
     assertEquals(expected2, dataSourceConverter.convert(source2));
   }
 

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
@@ -27,6 +27,33 @@ class DataSourceConverterTest {
   }
 
   @Test
+  void getArgumentsForMaxcomputeSource() throws JsonProcessingException {
+    DataSource source = 
+      DataSource.newBuilder()
+      .setEventTimestampColumn("event_timestamp")
+      .setType(DataSource.SourceType.BATCH_MAXCOMPUTE)
+      .setMaxcomputeOptions(
+        DataSource.MaxComputeOptions.newBuilder()
+          .setTableRef("project.schema.table")
+          .build())
+      .build();
+    DataSourceConverter dataSourceConverter = new DataSourceConverter();
+    String expected =  "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+    assertEquals(expected, dataSourceConverter.convert(source));
+    DataSource source2 = 
+      DataSource.newBuilder()
+      .setEventTimestampColumn("event_timestamp")
+      .setType(DataSource.SourceType.BATCH_MAXCOMPUTE)
+      .setMaxcomputeOptions(
+        DataSource.MaxComputeOptions.newBuilder()
+          .setTableRef("project:schema.table")
+          .build())
+      .build();
+    String expected2 =  "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+    assertEquals(expected2, dataSourceConverter.convert(source2));
+  }
+
+  @Test
   void getArgumentsForFileSource() throws JsonProcessingException {
     DataSource source =
         DataSource.newBuilder()

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
@@ -39,7 +39,7 @@ class DataSourceConverterTest {
             .build();
     DataSourceConverter dataSourceConverter = new DataSourceConverter();
     String expected =
-        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"schema\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+        "{\"maxCompute\":{\"project\":\"project\",\"dataset\":\"schema\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
     assertEquals(expected, dataSourceConverter.convert(source));
     DataSource source2 =
         DataSource.newBuilder()
@@ -51,7 +51,7 @@ class DataSourceConverterTest {
                     .build())
             .build();
     String expected2 =
-        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"schema\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+        "{\"maxCompute\":{\"project\":\"project\",\"dataset\":\"schema\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
     assertEquals(expected2, dataSourceConverter.convert(source2));
   }
 

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/adapter/DataSourceConverterTest.java
@@ -39,7 +39,7 @@ class DataSourceConverterTest {
             .build();
     DataSourceConverter dataSourceConverter = new DataSourceConverter();
     String expected =
-        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"schema\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
     assertEquals(expected, dataSourceConverter.convert(source));
     DataSource source2 =
         DataSource.newBuilder()
@@ -51,7 +51,7 @@ class DataSourceConverterTest {
                     .build())
             .build();
     String expected2 =
-        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"dataset\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
+        "{\"maxcompute\":{\"project\":\"project\",\"dataset\":\"schema\",\"table\":\"table\",\"eventTimestampColumn\":\"event_timestamp\",\"fieldMapping\":{}}}";
     assertEquals(expected2, dataSourceConverter.convert(source2));
   }
 

--- a/caraml-store-sdk/python/feast/maxcompute/staging.py
+++ b/caraml-store-sdk/python/feast/maxcompute/staging.py
@@ -69,12 +69,13 @@ def stage_entities_to_maxcompute(
 
     # Create table with timestamp partitioning
     full_table_name = f"{project}.{schema}.entities_{uuid.uuid4()}".replace("-", "_")
+    print("entity full_table_name: ", full_table_name)
 
     # Create columns for the table schema
     columns = []
     for col_name, dtype in entity_source.dtypes.items():
         if col_name == timestamp_column:
-            mc_type = "TIMESTAMP_NTZ"
+            mc_type = "TIMESTAMP"
         else:
             mc_type = dtype_to_mc_type.get(str(dtype), "STRING")
         columns.append(f"{col_name} {mc_type}")
@@ -83,7 +84,7 @@ def stage_entities_to_maxcompute(
 
     # Create the table
     mc_event_timestamp_column = f"{timestamp_column}_pt"
-    create_table_query = f"create table {full_table_name} ( {', '.join(columns)} )  auto partitioned by (trunc_time({timestamp_column}, 'day') as {mc_event_timestamp_column})"
+    create_table_query = f"create table {full_table_name} ( {', '.join(columns)} )  auto partitioned by (trunc_time({timestamp_column}, 'day') as {mc_event_timestamp_column}) lifecycle 1"
     print(f"query: {create_table_query}")
     odps_client.execute_sql(create_table_query)
 

--- a/caraml-store-sdk/python/feast/maxcompute/staging.py
+++ b/caraml-store-sdk/python/feast/maxcompute/staging.py
@@ -1,0 +1,99 @@
+import os
+import uuid
+import pandas as pd
+from datetime import datetime, timedelta
+from feast.data_source import MaxComputeSource
+from odps import ODPS
+from odps import df
+import numpy as np
+from odps.models import TableSchema, Column, Partition
+
+
+def stage_entities_to_maxcompute(
+    entity_source: pd.DataFrame,
+    project: str,
+    schema: str,
+    table_name: str,
+    timestamp_column: str = "event_timestamp",
+    endpoint: str = "",
+    access_key: str = "",
+    secret_key: str = "",
+) -> MaxComputeSource:
+    """
+    Stores given (entity) dataframe as new table in MaxCompute.
+    Table will expire in 1 day.
+    Returns MaxComputeSource with reference to created table.
+
+    Args:
+        entity_source: DataFrame containing entity data
+        project: MaxCompute project name
+        schema: MaxCompute schema name
+        table_name: Name for the table to be created
+        endpoint: MaxCompute endpoint URL (defaults to env var MAXCOMPUTE_ENDPOINT)
+        access_key: MaxCompute access key (defaults to env var MAXCOMPUTE_ACCESS_KEY)
+        secret_key: MaxCompute secret key (defaults to env var MAXCOMPUTE_SECRET_KEY)
+
+    Returns:
+        MaxComputeSource with reference to created table
+    """
+    # Get credentials from args or environment variables
+    endpoint = endpoint or os.getenv("MAXCOMPUTE_ENDPOINT")
+    access_key = access_key or os.getenv("MAXCOMPUTE_ACCESS_KEY")
+    secret_key = secret_key or os.getenv("MAXCOMPUTE_SECRET_KEY")
+
+    if not access_key or not secret_key:
+        raise ValueError(
+            "MaxCompute credentials not provided. Either pass access_key and secret_key "
+            "as arguments or set MAXCOMPUTE_ACCESS_KEY and MAXCOMPUTE_SECRET_KEY "
+            "environment variables."
+        )
+
+    # Initialize MaxCompute client
+    odps_client = ODPS(access_key, secret_key, project, endpoint=endpoint)
+
+    # Prevent casting ns -> ms exception inside pyarrow
+    entity_source[timestamp_column] = entity_source[timestamp_column].dt.floor("ms")
+
+    # Create table with timestamp partitioning
+    full_table_name = f"{project}.{schema}.{table_name}_{uuid.uuid4()}".replace(
+        "-", "_"
+    )
+    # Create table schema based on DataFrame columns
+    # Map pandas dtypes to MaxCompute types
+    dtype_to_mc_type = {
+        "object": "STRING",
+        "string": "STRING",
+        "int64": "BIGINT",
+        "int32": "INT",
+        "float64": "DOUBLE",
+        "float32": "FLOAT",
+        "bool": "BOOLEAN",
+        "datetime64[ns]": "TIMESTAMP",
+    }
+
+    # Create columns for the table schema
+    columns = []
+    for col_name, dtype in entity_source.dtypes.items():
+        mc_type = dtype_to_mc_type.get(str(dtype), "STRING")
+        columns.append(f"{col_name} {mc_type}")
+
+    timestamp_column = "event_timestamp"
+
+    # Create the table
+    mc_event_timestamp_column = f"{timestamp_column}_pt"
+    create_table_query = f"create table {full_table_name} ( {', '.join(columns)} )  auto partitioned by (trunc_time({timestamp_column}, 'day') as {mc_event_timestamp_column})"
+    print(f"query: {create_table_query}")
+    odps_client.execute_sql(create_table_query)
+
+    # Write DataFrame to MaxCompute table
+    odps_df = df.DataFrame(entity_source)
+    odps_df.persist(
+        full_table_name,
+        partition=f"{mc_event_timestamp_column}={timestamp_column}",
+        lifecycle=1,
+    )
+
+    return MaxComputeSource(
+        event_timestamp_column="event_timestamp",
+        table_ref=f"{full_table_name}",
+    )

--- a/caraml-store-sdk/python/feast/maxcompute/staging.py
+++ b/caraml-store-sdk/python/feast/maxcompute/staging.py
@@ -5,8 +5,6 @@ from datetime import datetime, timedelta
 from feast.data_source import MaxComputeSource
 from odps import ODPS
 from odps import df
-import numpy as np
-from odps.models import TableSchema, Column, Partition
 
 
 def stage_entities_to_maxcompute(

--- a/caraml-store-sdk/python/feast/maxcompute/staging.py
+++ b/caraml-store-sdk/python/feast/maxcompute/staging.py
@@ -84,7 +84,7 @@ def stage_entities_to_maxcompute(
 
     # Create the table
     mc_event_timestamp_column = f"{timestamp_column}_pt"
-    create_table_query = f"create table {full_table_name} ( {', '.join(columns)} )  auto partitioned by (trunc_time({timestamp_column}, 'day') as {mc_event_timestamp_column}) lifecycle 1"
+    create_table_query = f"create table if not exists {full_table_name} ( {', '.join(columns)} )  auto partitioned by (trunc_time({timestamp_column}, 'day') as {mc_event_timestamp_column}) lifecycle 1"
     print(f"query: {create_table_query}")
     odps_client.execute_sql(create_table_query)
 

--- a/caraml-store-sdk/python/requirements-ci.txt
+++ b/caraml-store-sdk/python/requirements-ci.txt
@@ -8,3 +8,4 @@ croniter==1.*
 black==22.12.0
 pytest==7.2.2
 mypy==1.1.1
+pyodps==0.12.2.1

--- a/caraml-store-sdk/python/setup.py
+++ b/caraml-store-sdk/python/setup.py
@@ -18,6 +18,9 @@ EXTRA_REQUIRED = {
     "gcp": [
         "pandas>=1.0.0",
         "google-cloud-bigquery>=3.0.0",
+    ],
+    "maxcompute": [
+        "pyodps==0.12.2.1",
     ]
 }
 


### PR DESCRIPTION
### Summary
* This MR adds a helper function to stage entities to maxcompute 
* Allows both `project.schema.table` and `project:schema.table` format for maxcompute datasources
* Add pyodps package as caraml-store-sdk dependency