### PR TITLE
Fix sdk_release pipeline

### DIFF
--- a/.github/workflows/sdk_release.yaml
+++ b/.github/workflows/sdk_release.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/sdk_release.yaml
+++ b/.github/workflows/sdk_release.yaml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # fetch full history for a proper version number assignment
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: 'pip'
           cache-dependency-path: '**/requirements-build.txt'
 


### PR DESCRIPTION
### Summary
* Bump github action versions
* Use python 3.8 instead of 3.7
* Tested sdk_release pipeline [here](https://github.com/caraml-dev/caraml-store/actions/runs/14570394333/job/40866478270?pr=143)