### PR TITLE
feat: use default max age when max_age is not provided

### DIFF
--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
@@ -170,9 +170,7 @@ public class FeatureTable extends AbstractTimestampEntity {
    * @throws IllegalArgumentException if the update will make prohibited changes.
    */
   public void updateFromProto(
-      String projectName,
-      FeatureTableSpec spec,
-      EntityRepository entityRepo) {
+      String projectName, FeatureTableSpec spec, EntityRepository entityRepo) {
     // Check for prohibited changes made in spec:
     // - Name cannot be changed
     if (!getName().equals(spec.getName())) {

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
@@ -172,8 +172,7 @@ public class FeatureTable extends AbstractTimestampEntity {
   public void updateFromProto(
       String projectName,
       FeatureTableSpec spec,
-      EntityRepository entityRepo,
-      Long defaultMaxAgeSeconds) {
+      EntityRepository entityRepo) {
     // Check for prohibited changes made in spec:
     // - Name cannot be changed
     if (!getName().equals(spec.getName())) {

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
@@ -124,7 +124,7 @@ public class FeatureTable extends AbstractTimestampEntity {
    * @return constructed FeatureTable from the given Protobuf spec.
    */
   public static FeatureTable fromProto(
-      String projectName, FeatureTableSpec spec, EntityRepository entityRepo) {
+      String projectName, FeatureTableSpec spec, EntityRepository entityRepo, Long defaultMaxAgeSeconds) {
     FeatureTable table = new FeatureTable();
     table.setName(spec.getName());
     table.setProject(new Project(projectName));
@@ -143,7 +143,12 @@ public class FeatureTable extends AbstractTimestampEntity {
     String labelsJSON = TypeConversion.convertMapToJsonString(spec.getLabelsMap());
     table.setLabelsJSON(labelsJSON);
 
-    table.setMaxAgeSecs(spec.getMaxAge().getSeconds());
+    Long maxAge = defaultMaxAgeSeconds;
+    if (spec.hasMaxAge()) {
+      maxAge = spec.getMaxAge().getSeconds();
+    }
+
+    table.setMaxAgeSecs(maxAge);
     table.setBatchSource(DataSource.fromProto(spec.getBatchSource()));
     table.setOnlineStore(OnlineStore.fromProto(spec.getOnlineStore()));
 
@@ -162,7 +167,7 @@ public class FeatureTable extends AbstractTimestampEntity {
    * @throws IllegalArgumentException if the update will make prohibited changes.
    */
   public void updateFromProto(
-      String projectName, FeatureTableSpec spec, EntityRepository entityRepo) {
+      String projectName, FeatureTableSpec spec, EntityRepository entityRepo, Long defaultMaxAgeSeconds) {
     // Check for prohibited changes made in spec:
     // - Name cannot be changed
     if (!getName().equals(spec.getName())) {
@@ -197,7 +202,11 @@ public class FeatureTable extends AbstractTimestampEntity {
                 })
             .collect(Collectors.toSet()));
 
-    this.maxAgeSecs = spec.getMaxAge().getSeconds();
+
+    if (spec.hasMaxAge()) {
+      this.maxAgeSecs = spec.getMaxAge().getSeconds();
+    }
+    
     this.labelsJSON = TypeConversion.convertMapToJsonString(spec.getLabelsMap());
 
     this.batchSource = DataSource.fromProto(spec.getBatchSource());

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/FeatureTable.java
@@ -124,7 +124,10 @@ public class FeatureTable extends AbstractTimestampEntity {
    * @return constructed FeatureTable from the given Protobuf spec.
    */
   public static FeatureTable fromProto(
-      String projectName, FeatureTableSpec spec, EntityRepository entityRepo, Long defaultMaxAgeSeconds) {
+      String projectName,
+      FeatureTableSpec spec,
+      EntityRepository entityRepo,
+      Long defaultMaxAgeSeconds) {
     FeatureTable table = new FeatureTable();
     table.setName(spec.getName());
     table.setProject(new Project(projectName));
@@ -167,7 +170,10 @@ public class FeatureTable extends AbstractTimestampEntity {
    * @throws IllegalArgumentException if the update will make prohibited changes.
    */
   public void updateFromProto(
-      String projectName, FeatureTableSpec spec, EntityRepository entityRepo, Long defaultMaxAgeSeconds) {
+      String projectName,
+      FeatureTableSpec spec,
+      EntityRepository entityRepo,
+      Long defaultMaxAgeSeconds) {
     // Check for prohibited changes made in spec:
     // - Name cannot be changed
     if (!getName().equals(spec.getName())) {
@@ -202,11 +208,10 @@ public class FeatureTable extends AbstractTimestampEntity {
                 })
             .collect(Collectors.toSet()));
 
-
     if (spec.hasMaxAge()) {
       this.maxAgeSecs = spec.getMaxAge().getSeconds();
     }
-    
+
     this.labelsJSON = TypeConversion.convertMapToJsonString(spec.getLabelsMap());
 
     this.batchSource = DataSource.fromProto(spec.getBatchSource());

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryConfig.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryConfig.java
@@ -11,4 +11,5 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 public class RegistryConfig {
   private Boolean syncIngestionJobOnSpecUpdate;
+  private Long featureTableDefaultMaxAgeSeconds;
 }

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryService.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryService.java
@@ -301,9 +301,7 @@ public class RegistryService {
       return ApplyFeatureTableResponse.newBuilder().setTable(existingTable.get().toProto()).build();
     }
     if (existingTable.isPresent()) {
-      existingTable
-          .get()
-          .updateFromProto(projectName, applySpec, entityRepository);
+      existingTable.get().updateFromProto(projectName, applySpec, entityRepository);
       table = existingTable.get();
     }
 

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryService.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryService.java
@@ -294,13 +294,16 @@ public class RegistryService {
     // Create or update depending on whether there is an existing Feature Table
     Optional<FeatureTable> existingTable =
         tableRepository.findFeatureTableByNameAndProject_Name(applySpec.getName(), projectName);
-    FeatureTable table = FeatureTable.fromProto(projectName, applySpec, entityRepository, defaultMaxAgeSeconds);
+    FeatureTable table =
+        FeatureTable.fromProto(projectName, applySpec, entityRepository, defaultMaxAgeSeconds);
     if (existingTable.isPresent() && table.equals(existingTable.get())) {
       // Skip update if no change is detected
       return ApplyFeatureTableResponse.newBuilder().setTable(existingTable.get().toProto()).build();
     }
     if (existingTable.isPresent()) {
-      existingTable.get().updateFromProto(projectName, applySpec, entityRepository, defaultMaxAgeSeconds);
+      existingTable
+          .get()
+          .updateFromProto(projectName, applySpec, entityRepository, defaultMaxAgeSeconds);
       table = existingTable.get();
     }
 

--- a/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryService.java
+++ b/caraml-store-registry/src/main/java/dev/caraml/store/feature/RegistryService.java
@@ -303,7 +303,7 @@ public class RegistryService {
     if (existingTable.isPresent()) {
       existingTable
           .get()
-          .updateFromProto(projectName, applySpec, entityRepository, defaultMaxAgeSeconds);
+          .updateFromProto(projectName, applySpec, entityRepository);
       table = existingTable.get();
     }
 

--- a/caraml-store-registry/src/main/resources/application.yaml
+++ b/caraml-store-registry/src/main/resources/application.yaml
@@ -2,6 +2,7 @@ caraml:
   registry:
     # Whether to create/update streaming ingestion jobs on feature table creation/update
     syncIngestionJobOnSpecUpdate: true
+    featureTableDefaultMaxAgeSeconds: 604800 # 7 days
 
   # Enable integration with MLP server
   mlp:

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobServiceTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobServiceTest.java
@@ -95,7 +95,8 @@ public class JobServiceTest {
         .thenReturn(
             new Entity("entity1", "", ValueProto.ValueType.Enum.STRING, Collections.emptyMap()));
     Long defaultMaxAgeSeconds = 100L;
-    FeatureTable featureTable = FeatureTable.fromProto(project, spec, entityRepository, defaultMaxAgeSeconds);
+    FeatureTable featureTable =
+        FeatureTable.fromProto(project, spec, entityRepository, defaultMaxAgeSeconds);
     when(tableRepository.findFeatureTableByNameAndProject_NameAndIsDeletedFalse(
             "batch_feature_table", project))
         .thenReturn(Optional.of(featureTable));
@@ -190,7 +191,8 @@ public class JobServiceTest {
         .thenReturn(
             new Entity("entity1", "", ValueProto.ValueType.Enum.STRING, Collections.emptyMap()));
     Long defaultMaxAgeSeconds = 100L;
-    List<FeatureTable> featureTables = List.of(FeatureTable.fromProto(project, spec, entityRepository, defaultMaxAgeSeconds));
+    List<FeatureTable> featureTables =
+        List.of(FeatureTable.fromProto(project, spec, entityRepository, defaultMaxAgeSeconds));
     when(tableRepository.findAllByProject_Name(project)).thenReturn(featureTables);
     jobservice.createOrUpdateStreamingIngestionJob(project, spec);
     SparkApplication expectedSparkApplication = new SparkApplication();

--- a/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobServiceTest.java
+++ b/caraml-store-registry/src/test/java/dev/caraml/store/sparkjob/JobServiceTest.java
@@ -94,7 +94,8 @@ public class JobServiceTest {
     when(entityRepository.findEntityByNameAndProject_Name("entity1", project))
         .thenReturn(
             new Entity("entity1", "", ValueProto.ValueType.Enum.STRING, Collections.emptyMap()));
-    FeatureTable featureTable = FeatureTable.fromProto(project, spec, entityRepository);
+    Long defaultMaxAgeSeconds = 100L;
+    FeatureTable featureTable = FeatureTable.fromProto(project, spec, entityRepository, defaultMaxAgeSeconds);
     when(tableRepository.findFeatureTableByNameAndProject_NameAndIsDeletedFalse(
             "batch_feature_table", project))
         .thenReturn(Optional.of(featureTable));
@@ -188,8 +189,8 @@ public class JobServiceTest {
     when(entityRepository.findEntityByNameAndProject_Name("entity1", project))
         .thenReturn(
             new Entity("entity1", "", ValueProto.ValueType.Enum.STRING, Collections.emptyMap()));
-    List<FeatureTable> featureTables =
-        List.of(FeatureTable.fromProto(project, spec, entityRepository));
+    Long defaultMaxAgeSeconds = 100L;
+    List<FeatureTable> featureTables = List.of(FeatureTable.fromProto(project, spec, entityRepository, defaultMaxAgeSeconds));
     when(tableRepository.findAllByProject_Name(project)).thenReturn(featureTables);
     jobservice.createOrUpdateStreamingIngestionJob(project, spec);
     SparkApplication expectedSparkApplication = new SparkApplication();

--- a/caraml-store-registry/src/test/resources/application-it.yaml
+++ b/caraml-store-registry/src/test/resources/application-it.yaml
@@ -1,3 +1,4 @@
 caraml:
   registry:
     syncIngestionJobOnSpecUpdate: false
+    featureTableDefaultMaxAgeSeconds: 2200

--- a/caraml-store-testutil/src/main/java/dev/caraml/store/testutils/it/DataGenerator.java
+++ b/caraml-store-testutil/src/main/java/dev/caraml/store/testutils/it/DataGenerator.java
@@ -71,38 +71,42 @@ public class DataGenerator {
       String name,
       List<String> entities,
       Map<String, ValueProto.ValueType.Enum> features,
-      int maxAgeSecs,
+      Integer maxAgeSecs,
       Map<String, String> labels) {
 
-    return FeatureTableSpec.newBuilder()
-        .setName(name)
-        .addAllEntities(entities)
-        .addAllFeatures(
-            features.entrySet().stream()
-                .map(
-                    entry ->
-                        FeatureSpec.newBuilder()
-                            .setName(entry.getKey())
-                            .setValueType(entry.getValue())
-                            .putAllLabels(labels)
+    FeatureTableSpec.Builder builder = FeatureTableSpec.newBuilder()
+            .setName(name)
+            .addAllEntities(entities)
+            .addAllFeatures(
+                    features.entrySet().stream()
+                            .map(
+                                    entry ->
+                                            FeatureSpec.newBuilder()
+                                                    .setName(entry.getKey())
+                                                    .setValueType(entry.getValue())
+                                                    .putAllLabels(labels)
+                                                    .build())
+                            .collect(Collectors.toList()))
+            .setBatchSource(
+                    DataSource.newBuilder()
+                            .setEventTimestampColumn("ts")
+                            .setType(DataSource.SourceType.BATCH_FILE)
+                            .setFileOptions(
+                                    FileOptions.newBuilder()
+                                            .setFileFormat(
+                                                    FileFormat.newBuilder()
+                                                            .setParquetFormat(ParquetFormat.newBuilder().build())
+                                                            .build())
+                                            .setFileUrl("/dev/null")
+                                            .build())
                             .build())
-                .collect(Collectors.toList()))
-        .setMaxAge(Duration.newBuilder().setSeconds(3600).build())
-        .setBatchSource(
-            DataSource.newBuilder()
-                .setEventTimestampColumn("ts")
-                .setType(DataSource.SourceType.BATCH_FILE)
-                .setFileOptions(
-                    FileOptions.newBuilder()
-                        .setFileFormat(
-                            FileFormat.newBuilder()
-                                .setParquetFormat(ParquetFormat.newBuilder().build())
-                                .build())
-                        .setFileUrl("/dev/null")
-                        .build())
-                .build())
-        .putAllLabels(labels)
-        .build();
+            .putAllLabels(labels);
+
+    if (maxAgeSecs != null) {
+      builder.setMaxAge(Duration.newBuilder().setSeconds(maxAgeSecs).build());
+    }
+
+    return builder.build();
   }
 
   public static FeatureTableSpec createFeatureTableSpec(

--- a/caraml-store-testutil/src/main/java/dev/caraml/store/testutils/it/DataGenerator.java
+++ b/caraml-store-testutil/src/main/java/dev/caraml/store/testutils/it/DataGenerator.java
@@ -74,32 +74,33 @@ public class DataGenerator {
       Integer maxAgeSecs,
       Map<String, String> labels) {
 
-    FeatureTableSpec.Builder builder = FeatureTableSpec.newBuilder()
+    FeatureTableSpec.Builder builder =
+        FeatureTableSpec.newBuilder()
             .setName(name)
             .addAllEntities(entities)
             .addAllFeatures(
-                    features.entrySet().stream()
-                            .map(
-                                    entry ->
-                                            FeatureSpec.newBuilder()
-                                                    .setName(entry.getKey())
-                                                    .setValueType(entry.getValue())
-                                                    .putAllLabels(labels)
-                                                    .build())
-                            .collect(Collectors.toList()))
+                features.entrySet().stream()
+                    .map(
+                        entry ->
+                            FeatureSpec.newBuilder()
+                                .setName(entry.getKey())
+                                .setValueType(entry.getValue())
+                                .putAllLabels(labels)
+                                .build())
+                    .collect(Collectors.toList()))
             .setBatchSource(
-                    DataSource.newBuilder()
-                            .setEventTimestampColumn("ts")
-                            .setType(DataSource.SourceType.BATCH_FILE)
-                            .setFileOptions(
-                                    FileOptions.newBuilder()
-                                            .setFileFormat(
-                                                    FileFormat.newBuilder()
-                                                            .setParquetFormat(ParquetFormat.newBuilder().build())
-                                                            .build())
-                                            .setFileUrl("/dev/null")
-                                            .build())
+                DataSource.newBuilder()
+                    .setEventTimestampColumn("ts")
+                    .setType(DataSource.SourceType.BATCH_FILE)
+                    .setFileOptions(
+                        FileOptions.newBuilder()
+                            .setFileFormat(
+                                FileFormat.newBuilder()
+                                    .setParquetFormat(ParquetFormat.newBuilder().build())
+                                    .build())
+                            .setFileUrl("/dev/null")
                             .build())
+                    .build())
             .putAllLabels(labels);
 
     if (maxAgeSecs != null) {


### PR DESCRIPTION
Summary:
- added new config featureTableDefaultMaxAgeSeconds
- use defaultMaxAge in feature-table creation in case maxAge is not provided
- use last set maxAge if feature-table update is provided with maxAge