### PR TITLE
fix: do not persist validRows when debug is enabled

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BatchPipeline.scala
@@ -76,16 +76,9 @@ object BatchPipeline extends BasePipeline {
 
     implicit val rowEncoder: Encoder[Row] = RowEncoder(projected.schema)
 
-    val validRows = if (config.debug) {
-      projected
-        .map(metrics.incrementRead)
-        .filter(rowValidator.allChecks)
-        .persist()
-    } else {
-      projected
-        .map(metrics.incrementRead)
-        .filter(rowValidator.allChecks)
-    }
+    val validRows = projected
+      .map(metrics.incrementRead)
+      .filter(rowValidator.allChecks)
 
     if (config.debug) {
       val validRowCount = validRows.count()


### PR DESCRIPTION
### Summary
* Previously, if debug was enabled, 2 copies would be persisted in memory
* This usually results in the executor being oomkilled
* This mr fixes this by removing the persist() method call for validRows. The result is that 2 calls to the data source (ie maxcompute / bigquery) will be run to fetch the data when debug mode is enabled. This should be acceptable as we are running --debug mode only to resolve errors / during development and not in production.