### PR TITLE
feat: added OSS filesystem config

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -18,12 +18,17 @@ object BasePipeline {
 
     val conf = new SparkConf()
 
-    // OSS connection and credential
-    conf.set("spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS")
-    conf.set("spark.hadoop.fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem")
-    conf.set("spark.hadoop.fs.oss.endpoint", sys.env("OSS_ENDPOINT"))
-    conf.set("spark.hadoop.fs.oss.accessKeyId", sys.env("OSS_ACCESS_KEY_ID"))
-    conf.set("spark.hadoop.fs.oss.accessKeySecret", sys.env("OSS_ACCESS_KEY_SECRET"))
+    // OSS connection and credential if needed
+    val dlPath = jobConfig.deadLetterPath.getOrElse("")
+    val cpPath = jobConfig.checkpointPath.getOrElse("")
+    val ossPrefix = "oss://"
+    if (dlPath.startsWith(ossPrefix) || cpPath.startsWith(ossPrefix)) {
+      conf.set("spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS")
+      conf.set("spark.hadoop.fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem")
+      conf.set("spark.hadoop.fs.oss.endpoint", sys.env("OSS_ENDPOINT"))
+      conf.set("spark.hadoop.fs.oss.accessKeyId", sys.env("OSS_ACCESS_KEY_ID"))
+      conf.set("spark.hadoop.fs.oss.accessKeySecret", sys.env("OSS_ACCESS_KEY_SECRET"))
+    }
 
     jobConfig.store match {
       case RedisConfig(host, port, password, ssl, properties) =>


### PR DESCRIPTION
Summary: Adding OSS filesystem connectivity config and credential through env vars. Previously I attempted to pass this via file but OSS API is not officially supporting that.