### PR TITLE
Improve batch ingestion pipeline

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -19,8 +19,8 @@ object BasePipeline {
     val conf = new SparkConf()
 
     // OSS connection and credential if needed
-    val dlPath = jobConfig.deadLetterPath.getOrElse("")
-    val cpPath = jobConfig.checkpointPath.getOrElse("")
+    val dlPath    = jobConfig.deadLetterPath.getOrElse("")
+    val cpPath    = jobConfig.checkpointPath.getOrElse("")
     val ossPrefix = "oss://"
     if (dlPath.startsWith(ossPrefix) || cpPath.startsWith(ossPrefix)) {
       conf.set("spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS")

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -101,10 +101,12 @@ object BasePipeline {
       case None => ()
     }
 
-    SparkSession
+    val spark = SparkSession
       .builder()
       .config(conf)
       .getOrCreate()
+    spark.sparkContext.setLogLevel("DEBUG") // Sets log level to DEBUG
+    spark
   }
 
   /**

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -105,7 +105,6 @@ object BasePipeline {
       .builder()
       .config(conf)
       .getOrCreate()
-    spark.sparkContext.setLogLevel("DEBUG") // Sets log level to DEBUG
     spark
   }
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
@@ -17,7 +17,6 @@ object IngestionJob {
     ShortTypeHints(List(classOf[ProtoFormat], classOf[AvroFormat]))
 
   private val logger = Logger.getLogger(getClass.getCanonicalName)
-  Logger.getRootLogger.setLevel(Level.DEBUG) // Sets Log4j root logger level
 
   val parser = new scopt.OptionParser[IngestionJobConfig]("IngestionJob") {
     // ToDo: read version from Manifest

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJob.scala
@@ -2,7 +2,7 @@ package dev.caraml.spark
 
 import dev.caraml.spark.utils.JsonUtils
 import dev.caraml.store.protobuf.types.ValueProto.ValueType
-import org.apache.log4j.Logger
+import org.apache.log4j.{Level, Logger}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.json4s._
 import org.json4s.ext.JavaEnumNameSerializer
@@ -17,6 +17,7 @@ object IngestionJob {
     ShortTypeHints(List(classOf[ProtoFormat], classOf[AvroFormat]))
 
   private val logger = Logger.getLogger(getClass.getCanonicalName)
+  Logger.getRootLogger.setLevel(Level.DEBUG) // Sets Log4j root logger level
 
   val parser = new scopt.OptionParser[IngestionJobConfig]("IngestionJob") {
     // ToDo: read version from Manifest

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -136,7 +136,7 @@ case class MaxComputeConfig(
     interactiveMode: Boolean = true,
     enableLimit: Boolean = false,
     autoSelectLimit: String = "1000000000",
-    fetchSize: Int = 1000000000
+    fetchSize: Int = 10000
 )
 
 case class IngestionJobConfig(

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/IngestionJobConfig.scala
@@ -135,7 +135,8 @@ case class MaxComputeConfig(
     endpoint: String = "",
     interactiveMode: Boolean = true,
     enableLimit: Boolean = false,
-    autoSelectLimit: String = "1000000000"
+    autoSelectLimit: String = "1000000000",
+    fetchSize: Int = 1000000000
 )
 
 case class IngestionJobConfig(

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -20,7 +20,7 @@ object MaxComputeReader {
     val config = maxComputeConfig.getOrElse(MaxComputeConfig())
 
     val maxComputeJDBCConnectionURL =
-      "jdbc:odps:%s/?project=%s&interactiveMode=%s&enableLimit=%s&autoSelectLimit=%s"
+      "jdbc:odps:%s/?project=%s&interactiveMode=%s&enableLimit=%s&autoSelectLimit=%s&enableOdpsLogger=true"
         .format(
           config.endpoint,
           source.project,
@@ -46,6 +46,7 @@ object MaxComputeReader {
       .option("dbtable", sqlQuery)
       .option("user", maxComputeAccessID)
       .option("password", maxComputeAccessKey)
+      .option("queryTimeout", 21600)
       .load()
 
     data.toDF()

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -20,7 +20,7 @@ object MaxComputeReader {
     val config = maxComputeConfig.getOrElse(MaxComputeConfig())
 
     val maxComputeJDBCConnectionURL =
-      "jdbc:odps:%s/?project=%s&interactiveMode=%s&enableLimit=%s&autoSelectLimit=%s&enableOdpsLogger=true"
+      "jdbc:odps:%s/?project=%s&interactiveMode=%s&enableLimit=%s&autoSelectLimit=%s&enableOdpsLogger=true&alwaysFallback=true"
         .format(
           config.endpoint,
           source.project,

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -41,8 +41,8 @@ object MaxComputeReader {
     sparkSession.read
       .format("jdbc")
       .option("url", maxComputeJDBCConnectionURL)
-      // Not setting queryTimeout will fail the query, whereas setting it up actually doesn't make an impact
       .option("sessionInitStatement", "set odps.stage.reducer.num=50")
+      // Not setting queryTimeout will fail the query, whereas setting it up actually doesn't make an impact
       .option("queryTimeout", 5000)
       .option("dbtable", sqlQuery)
       .option("user", maxComputeAccessID)

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -42,10 +42,15 @@ object MaxComputeReader {
       .format("jdbc")
       .option("url", maxComputeJDBCConnectionURL)
       // Not setting queryTimeout will fail the query, whereas setting it up actually doesn't make an impact
+      .option("sessionInitStatement", "set odps.stage.reducer.num=50")
       .option("queryTimeout", 5000)
       .option("dbtable", sqlQuery)
       .option("user", maxComputeAccessID)
       .option("password", maxComputeAccessKey)
+      .option("partitionColumn", source.eventTimestampColumn)
+      .option("lowerBound", start.toString())
+      .option("upperBound", end.toString())
+      .option("numPartitions", 5)
       .option("fetchsize", config.fetchSize)
       .load()
 

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -47,6 +47,7 @@ object MaxComputeReader {
       .option("user", maxComputeAccessID)
       .option("password", maxComputeAccessKey)
       .option("queryTimeout", 21600)
+      .option("fetchsize", 1000000)
       .load()
 
     data.toDF()

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -46,8 +46,7 @@ object MaxComputeReader {
       .option("dbtable", sqlQuery)
       .option("user", maxComputeAccessID)
       .option("password", maxComputeAccessKey)
-      .option("queryTimeout", 21600)
-      .option("fetchsize", 1000000)
+      // .option("fetchsize", 1000000)
       .load()
 
     data.toDF()

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -38,7 +38,7 @@ object MaxComputeReader {
     val customDialect = new CustomDialect()
     JdbcDialects.registerDialect(customDialect)
 
-    val data = sparkSession.read
+    sparkSession.read
       .format("jdbc")
       .option("url", maxComputeJDBCConnectionURL)
       // Not setting queryTimeout will fail the query, whereas setting it up actually doesn't make an impact
@@ -49,6 +49,5 @@ object MaxComputeReader {
       .option("fetchsize", config.fetchSize)
       .load()
 
-    data.toDF()
   }
 }

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/sources/maxCompute/MaxComputeReader.scala
@@ -46,7 +46,7 @@ object MaxComputeReader {
       .option("dbtable", sqlQuery)
       .option("user", maxComputeAccessID)
       .option("password", maxComputeAccessKey)
-      // .option("fetchsize", 1000000)
+      .option("fetchsize", config.fetchSize)
       .load()
 
     data.toDF()


### PR DESCRIPTION
### Summary
- improve logging in spark job
- add jdbc partitioning options, to partition by event timestamp column and use start date and end date as partition boundary
- add `alwaysFallback=true` parameter so switch to offline mode for queries that involve large tables