### PR TITLE
Fix/spark oss implementation

### DIFF
--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -23,7 +23,7 @@ object BasePipeline {
     val cpPath    = jobConfig.checkpointPath.getOrElse("")
     val ossPrefix = "oss://"
     if (dlPath.startsWith(ossPrefix) || cpPath.startsWith(ossPrefix)) {
-      conf.set("spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS")
+      // conf.set("spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS")
       conf.set("spark.hadoop.fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem")
       conf.set("spark.hadoop.fs.oss.endpoint", sys.env("OSS_ENDPOINT"))
       conf.set("spark.hadoop.fs.oss.accessKeyId", sys.env("OSS_ACCESS_KEY_ID"))

--- a/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
+++ b/caraml-store-spark/src/main/scala/dev/caraml/spark/BasePipeline.scala
@@ -23,7 +23,6 @@ object BasePipeline {
     val cpPath    = jobConfig.checkpointPath.getOrElse("")
     val ossPrefix = "oss://"
     if (dlPath.startsWith(ossPrefix) || cpPath.startsWith(ossPrefix)) {
-      // conf.set("spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS")
       conf.set("spark.hadoop.fs.oss.impl", "org.apache.hadoop.fs.aliyun.oss.AliyunOSSFileSystem")
       conf.set("spark.hadoop.fs.oss.endpoint", sys.env("OSS_ENDPOINT"))
       conf.set("spark.hadoop.fs.oss.accessKeyId", sys.env("OSS_ACCESS_KEY_ID"))


### PR DESCRIPTION
Summary:
We got this error running spark jobs in kubernetes cluster: Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: Class org.apache.hadoop.fs.aliyun.oss.OSS not found  

Turns out in the hadoop aliyun library version that we use, that class doesn't exist. After efforts of resolving dependencies that, in the end, was not working, we found a solution with just removing the line that tries to access said class.

remove this: spark.hadoop.fs.AbstractFileSystem.oss.impl", "org.apache.hadoop.fs.aliyun.oss.OSS

It's working now.