### PR TITLE
fix: group checkpoint outputs into the same spark app id directory

### DIFF
--- a/caraml-store-pyspark/scripts/historical_feature_retrieval_job.py
+++ b/caraml-store-pyspark/scripts/historical_feature_retrieval_job.py
@@ -1082,6 +1082,7 @@ def feature_table_from_dict(dct: Dict[str, Any]) -> FeatureTable:
 
 if __name__ == "__main__":
     log_level = os.environ.get("SPARK_LOG_LEVEL")
+    app_id = os.environ.get("SPARK_APPLICATION_ID")
     args = _get_args()
     feature_tables_conf = json.loads(args.feature_tables)
     feature_tables_sources_conf = json.loads(args.feature_tables_sources)
@@ -1104,6 +1105,7 @@ if __name__ == "__main__":
         if log_level:
             spark.sparkContext.setLogLevel(log_level)
         if checkpoint:
+            checkpoint = checkpoint.rstrip("/") + f"/{app_id}"
             spark.sparkContext.setCheckpointDir(checkpoint)
 
         start_job(


### PR DESCRIPTION
Currently, all historical checkpoints are stored directly within a single, flat directory (`--checkpoint`), which makes object storage difficult to manage. This change introduces `SPARK_APPLICATION_ID` (e.g. `spark-7b144ce32e4c444f938223821d2f6538`) into the checkpoint path, grouping all related checkpoints of related spark job under the same directory. This aligns with the pattern already used in stream ingestion.
https://github.com/caraml-dev/caraml-store/blob/01a756f133cf9cd55ba287b3c291fe71dc6723fb/caraml-store-spark/src/main/scala/dev/caraml/spark/StreamingPipeline.scala#L172-L180